### PR TITLE
Optimize slider component

### DIFF
--- a/src/app/demo/slider/basic/app.component.html
+++ b/src/app/demo/slider/basic/app.component.html
@@ -2,38 +2,47 @@
 <jigsaw-demo-description [summary]="summary" [content]="description">
 </jigsaw-demo-description>
 
+<div class="live-demo-wrap">
+    <h2>Slider</h2>
+    <div class="demo-1 live-demo">
+        <h3>基本滑动条,滑动事件变化</h3>
+        <jigsaw-switch [(checked)]="disabled" size="small"></jigsaw-switch>
+        <jigsaw-slider [(value)]="value1" [disabled]="disabled" (change)="sliderChange($event)" min="10"
+                       width="200"></jigsaw-slider>
+        <p class="message"> 取值: {{value1}}</p>
+    </div>
 
-<!-- start to learn the demo from here -->
-<h4>1. 基本滑动条,滑动事件变化. </h4>
-<jigsaw-switch [(checked)]="disabled" size="small"></jigsaw-switch>
-<jigsaw-slider [(value)]="value1" [disabled]="disabled" (change)="sliderChange($event)" min="10" width="200"></jigsaw-slider>
-<span> 取值: {{value1}}</span>
-<hr>
-<br>
-<h4>2. 设置了min和max的滑动条</h4>
-<jigsaw-slider style="margin: 20px 0; " [value]="value" [min]="min" [max]="max"
-               (change)="sliderChange2($event)"></jigsaw-slider> <span>取值: {{value2}}</span>
-<hr>
-<br>
-<h4>3. 改变step</h4>
-<jigsaw-slider [value]="valueStep" min="0" max="2" step="0.01" (change)="sliderChange3($event)"></jigsaw-slider>
-<span>取值: {{value3}}</span>
+    <div class="demo-2 live-demo">
+        <h3>设置了min和max的滑动条</h3>
+        <jigsaw-slider [value]="value2" [min]="min" [max]="max"
+                       (change)="sliderChange2($event)"></jigsaw-slider>
+        <p class="message">取值: {{value2}}</p>
+    </div>
 
-<hr>
-<br>
-<h4>4. 双触点滑动条</h4>
-<jigsaw-slider [(value)]="rangeValue" (change)="handleValueChange($event)"></jigsaw-slider>
+    <div class="demo-3 live-demo">
+        <h3>改变step</h3>
+        <jigsaw-slider [value]="valueStep" min="0" max="2" step="0.01" (change)="sliderChange3($event)"></jigsaw-slider>
+        <p class="message">取值: {{value3}}</p>
+    </div>
 
-<hr>
-<br>
-<h4>5. mark 节点.</h4>
-<jigsaw-slider [marks]="marks" [value]="50"></jigsaw-slider>
+    <div class="demo-4 live-demo">
+        <h3>双触点滑动条</h3>
+        <jigsaw-slider [(value)]="rangeValue" (change)="handleValueChange($event)"></jigsaw-slider>
+    </div>
 
-<hr>
-<br>
-<h4>6. 垂直滑动条.</h4>
-<jigsaw-slider [value]="rangeValue2" [vertical]="vertical" class="vertical"
-               style="height: 240px; width: 60px;"></jigsaw-slider>
+    <div class="demo-5 live-demo">
+        <h3>mark节点</h3>
+        <jigsaw-slider [marks]="marks" value="50"></jigsaw-slider>
+    </div>
 
-<jigsaw-slider #slider [value]="120" [marks]="marks2" min="20" [vertical]="vertical"
-               class="vertical3"></jigsaw-slider>
+    <div class="demo-6 live-demo">
+        <h3>垂直滑动条</h3>
+        <p class="comment">垂直滑动条有默认高度`240px`</p>
+        <div class="inline mgr50">
+            <jigsaw-slider [(value)]="value6" vertical="true"></jigsaw-slider>
+            <p class="message">{{value6}}</p>
+        </div>
+        <jigsaw-slider class="mgr50" [(value)]="rangeValue2" vertical="true"></jigsaw-slider>
+        <jigsaw-slider #slider value="80" [marks]="marks2" min="20" vertical="true" height="400"></jigsaw-slider>
+    </div>
+</div>

--- a/src/app/demo/slider/basic/app.component.html
+++ b/src/app/demo/slider/basic/app.component.html
@@ -43,6 +43,6 @@
             <p class="message">{{value6}}</p>
         </div>
         <jigsaw-slider class="mgr50" [(value)]="rangeValue2" vertical="true"></jigsaw-slider>
-        <jigsaw-slider #slider value="80" [marks]="marks2" min="20" vertical="true" height="400"></jigsaw-slider>
+        <jigsaw-slider value="80" [marks]="marks2" min="20" vertical="true" height="400"></jigsaw-slider>
     </div>
 </div>

--- a/src/app/demo/slider/basic/app.component.scss
+++ b/src/app/demo/slider/basic/app.component.scss
@@ -1,19 +1,8 @@
-
-.vertical {
-    height: 240px;
-    width: 120px;
+.mgr50 {
+    margin-right: 50px;
 }
 
-.vertical3 {
-    height: 360px;
-    width: 120px;
-    display: inline-block!important;
-}
-
-jigsaw-slider:focus, jigsaw-slider:hover {
-    outline: none;
-}
-
-jigsaw-slider::selection {
-    background-color: transparent;
+.inline {
+    display: inline-block;
+    vertical-align: middle;
 }

--- a/src/app/demo/slider/basic/app.component.ts
+++ b/src/app/demo/slider/basic/app.component.ts
@@ -1,7 +1,4 @@
-/**
- * Created by 10177553 on 2017/4/13.
- */
-import {Component, OnInit} from '@angular/core';
+import {Component} from '@angular/core';
 import {SliderMark} from "jigsaw/component/slider/slider";
 import {ArrayCollection} from "jigsaw/core/data/array-collection";
 

--- a/src/app/demo/slider/basic/app.component.ts
+++ b/src/app/demo/slider/basic/app.component.ts
@@ -9,16 +9,33 @@ import {ArrayCollection} from "jigsaw/core/data/array-collection";
     templateUrl: './app.component.html',
     styleUrls: ['./app.component.scss']
 })
-export class SliderBasicDemoComponent implements OnInit {
+export class SliderBasicDemoComponent {
+    // demo1
     value1: number = 30;
-    value: number = 10;
     disabled: boolean = false;
 
+    sliderChange(value) {
+        console.info("当前值: " + value);
+    }
+
+    // demo2
+    value2: number = 10;
     min = 1;
     max = 20;
 
+    sliderChange2(value) {
+        this.value2 = value;
+    }
+
+    // demo3
+    value3;
     valueStep = 1;
 
+    public sliderChange3(value) {
+        this.value3 = value;
+    }
+
+    // demo4
     rangeValue = new ArrayCollection([30, 50, 60]);
 
     handleValueChange(value) {
@@ -26,6 +43,7 @@ export class SliderBasicDemoComponent implements OnInit {
         console.log(value);
     }
 
+    // demo5
     marks = [
         {value: 20, label: '20 ℃'},
         {value: 40, label: '40 ℃'},
@@ -34,34 +52,15 @@ export class SliderBasicDemoComponent implements OnInit {
         }
     ];
 
+    // demo6
+    value6 = 10;
+    vertical = true;
+    rangeValue2 = new ArrayCollection([10, 80]);
     marks2: SliderMark[] = [
         {value: 20, label: '20 ℃'},
         {value: 40, label: '40 ℃'},
         {value: 80, label: '80 ℃'}
     ];
-
-    sliderChange(value) {
-        console.info("当前值: " + value);
-    }
-
-    value2;
-
-    sliderChange2(value) {
-        this.value2 = value;
-    }
-
-    value3;
-
-    public sliderChange3(value) {
-        this.value3 = value;
-    }
-
-    rangeValue2 = new ArrayCollection([10, 80]);
-
-    ngOnInit() {
-    }
-
-    vertical = true;
 
     // ====================================================================
     // ignore the following lines, they are not important to this demo

--- a/src/app/demo/slider/vertical/app.component.html
+++ b/src/app/demo/slider/vertical/app.component.html
@@ -4,4 +4,4 @@
 
 
 <!-- start to learn the demo from here -->
-<jigsaw-slider min="10" max="100" [value]="value" [vertical]="vertical" style="height: 360px; width: 120px;"></jigsaw-slider>
+<jigsaw-slider min="10" max="100" [value]="value" vertical="true" height="360"></jigsaw-slider>

--- a/src/app/demo/slider/vertical/app.component.ts
+++ b/src/app/demo/slider/vertical/app.component.ts
@@ -5,10 +5,7 @@ import {Component} from '@angular/core';
 import {ArrayCollection} from "jigsaw/core/data/array-collection";
 
 @Component({
-    template: `
-        <jigsaw-slider min="10" max="100" [value]="value" [vertical]="vertical"
-                       style="height: 360px; width: 120px;"></jigsaw-slider>
-    `
+    templateUrl: 'app.component.html'
 })
 export class SliderVerticalDemoComponent {
     vertical: boolean = true;

--- a/src/jigsaw/component/slider/handle.html
+++ b/src/jigsaw/component/slider/handle.html
@@ -1,5 +1,3 @@
 <div class="jigsaw-slider-handle"
      [ngStyle]="_$handleStyle"
-     (mousedown)="_$updateCanDragged(true)"
-     (mousemove)="_$updateValuePosition($event)"
-     (mouseup)="_$updateCanDragged(false)"></div>
+     (mousedown)="_$startToDrag()"></div>

--- a/src/jigsaw/component/slider/slider.html
+++ b/src/jigsaw/component/slider/slider.html
@@ -1,22 +1,19 @@
 <div class="jigsaw-slider"
      [class.jigsaw-slider-disabled]="disabled"
-     [class.jigsaw-slider-with-marks]="marks&& marks.length > 0"
-     [class.jigsaw-slider-vertical]="vertical"
->
-    <!--(mousedown)="_updateCanDragged(true)"-->
-    <!--(mouseup)="_updateValuePosition($event)"-->
-    <!--(click)="_updateCanDragged(false)"-->
+     [class.jigsaw-slider-with-marks]="marks&& marks.length > 0">
 
     <div class="jigsaw-slider-rail"></div>
     <div class="jigsaw-slider-track" [ngStyle]="_$trackStyle"></div>
 
     <div class="jigsaw-slider-step">
-        <span *ngFor="let mark of _$marks" class="jigsaw-slider-dot jigsaw-slider-dot-active" [ngStyle]="mark.dotStyle"></span>
+        <span *ngFor="let mark of _$marks" class="jigsaw-slider-dot jigsaw-slider-dot-active"
+              [ngStyle]="mark.dotStyle"></span>
     </div>
 
     <slider-handle *ngFor="let item of _$value;let i = index" value="{{item}}" [key]="i"></slider-handle>
 
     <div *ngIf="_$marks.length > 0" class="jigsaw-slider-mark">
-        <span *ngFor="let mark of _$marks" class="jigsaw-slider-mark-text" [ngStyle]="mark.labelStyle">{{mark.label}}</span>
+        <span *ngFor="let mark of _$marks" class="jigsaw-slider-mark-text"
+              [ngStyle]="mark.labelStyle">{{mark.label}}</span>
     </div>
 </div>

--- a/src/jigsaw/component/slider/slider.scss
+++ b/src/jigsaw/component/slider/slider.scss
@@ -4,9 +4,9 @@
 $jigsaw-slider: #{$jigsaw-prefix}-slider;
 
 .#{$jigsaw-slider}-host {
-    height: 100%;
     width: 100%;
     @include inline-block;
+    padding: 0 6px;
     user-select: none;
     ::selection {
         background-color: #fff;
@@ -58,7 +58,7 @@ $jigsaw-slider: #{$jigsaw-prefix}-slider;
         position: absolute;
         margin-left: -7px;
         margin-top: -5px;
-        width:14px;
+        width: 14px;
         height: 14px;
         border-radius: 50%;
         border: 2px solid mix($primary-color, #fff, 50%);
@@ -81,8 +81,8 @@ $jigsaw-slider: #{$jigsaw-prefix}-slider;
     .#{$jigsaw-slider}-mark {
         position: absolute;
         top: 10px;
-        left:0;
-        width:100%;
+        left: 0;
+        width: 100%;
         height: 100%;
         font-size: $font-size-base;
         z-index: 3;
@@ -103,7 +103,7 @@ $jigsaw-slider: #{$jigsaw-prefix}-slider;
 
     .#{$jigsaw-slider}-step {
         position: absolute;
-        width:100%;
+        width: 100%;
         height: 4px;
         background: transparent;
         z-index: 1;
@@ -139,7 +139,7 @@ $jigsaw-slider: #{$jigsaw-prefix}-slider;
 
         .#{$jigsaw-slider}-handle,
         .#{$jigsaw-slider}-dot {
-            border-color: $disabled-color!important;
+            border-color: $disabled-color !important;
             background-color: $default-color;
             cursor: not-allowed;
             box-shadow: none;
@@ -151,46 +151,52 @@ $jigsaw-slider: #{$jigsaw-prefix}-slider;
 
         .#{$jigsaw-slider}-masr-text,
         .#{$jigsaw-slider}-dot {
-            cursor: not-allowed!important;
+            cursor: not-allowed !important;
         }
     }
 
     &-vertical {
-        width: 12px;
-        height: 100%;
-        margin: 6px 10px;
-        border: 4px;
-        border-left: 4px solid #fff;
-        border-right: 4px solid #fff;
-
-        .#{$jigsaw-slider}-track {
-            width: 4px;
-        }
-
-        .#{$jigsaw-slider}-handle {
-            margin-left: -5px;
-            margin-bottom: -7px;
-        }
-
-        .#{$jigsaw-slider}-mark {
-            top: 10px;
-            left: 10px;
-        }
-        .#{$jigsaw-slider}-mark-text {
-            white-space: nowrap;
-        }
-
-        .#{$jigsaw-slider}-step {
-            width: 4px;
+        height: 240px;
+        width: auto;
+        padding: 6px 0;
+        .#{$jigsaw-slider} {
+            width: 12px;
             height: 100%;
-        }
+            //margin: 6px 10px;
+            border: 4px;
+            border-left: 4px solid #fff;
+            border-right: 4px solid #fff;
 
-        .#{$jigsaw-slider}-dot {
-            top: auto;
-            left: 2px;
-            margin-bottom: -4px;
+            .#{$jigsaw-slider}-track {
+                width: 4px;
+            }
+
+            .#{$jigsaw-slider}-handle {
+                margin-left: -5px;
+                margin-bottom: -7px;
+            }
+
+            .#{$jigsaw-slider}-mark {
+                top: 10px;
+                left: 10px;
+            }
+            .#{$jigsaw-slider}-mark-text {
+                white-space: nowrap;
+            }
+
+            .#{$jigsaw-slider}-step {
+                width: 4px;
+                height: 100%;
+            }
+
+            .#{$jigsaw-slider}-dot {
+                top: auto;
+                left: 2px;
+                margin-bottom: -4px;
+            }
         }
     }
+
 }
 
 

--- a/src/jigsaw/component/slider/slider.ts
+++ b/src/jigsaw/component/slider/slider.ts
@@ -495,6 +495,7 @@ export class JigsawSlider extends AbstractJigsawComponent implements ControlValu
 
     private _propagateChange: any = () => {};
 
+    // ngModel触发的writeValue方法，只会在ngOnInit,ngAfterContentInit,ngAfterViewInit这些生命周期之后才调用
     public writeValue(value: any): void {
         if (value instanceof ArrayCollection) {
             this._$value = value;
@@ -511,6 +512,12 @@ export class JigsawSlider extends AbstractJigsawComponent implements ControlValu
             this.valueChange.emit(this.value);
             this._propagateChange(this.value);
         });
+
+        if (this.initialized) {
+            this._setTrackStyle(this.value);
+            this.valueChange.emit(this.value);
+            this._propagateChange(this.value);
+        }
     }
 
     public registerOnChange(fn: any): void {

--- a/src/jigsaw/component/slider/slider.ts
+++ b/src/jigsaw/component/slider/slider.ts
@@ -497,11 +497,13 @@ export class JigsawSlider extends AbstractJigsawComponent implements ControlValu
     // ngModel触发的writeValue方法，只会在ngOnInit,ngAfterContentInit,ngAfterViewInit这些生命周期之后才调用
     public writeValue(value: any): void {
         if (value instanceof ArrayCollection) {
-            this._$value = value;
-            if (this._removeRefreshCallback) {
-                this._removeRefreshCallback();
+            if (this._$value !== value) {
+                this._$value = value;
+                if (this._removeRefreshCallback) {
+                    this._removeRefreshCallback();
+                }
+                this._removeRefreshCallback = this._getRemoveRefreshCallback();
             }
-            this._removeRefreshCallback = this._getRemoveRefreshCallback();
         } else {
             this._$value.splice(0, this._$value.length);
             this._$value.push(this._verifyValue(+value));

--- a/src/jigsaw/component/slider/slider.ts
+++ b/src/jigsaw/component/slider/slider.ts
@@ -31,7 +31,7 @@ export class SliderMark {
     templateUrl: './handle.html',
     encapsulation: ViewEncapsulation.None
 })
-export class JigsawSliderHandle implements OnInit{
+export class JigsawSliderHandle implements OnInit {
 
     private _value: number;
 
@@ -39,16 +39,19 @@ export class JigsawSliderHandle implements OnInit{
     public key: number;
 
     @Input()
-    public get value() { return this._value; }
+    public get value() {
+        return this._value;
+    }
+
     public set value(value) {
-        if(this._value === value) return;
+        if (this._value === value) return;
 
         this._value = this._slider._verifyValue(value);
         this._valueToPos();
     }
 
     @Output()
-    public change = new  EventEmitter<number>();
+    public change = new EventEmitter<number>();
 
     private _valueToPos() {
         this._offset = this._slider._transformValueToPos(this.value);
@@ -63,9 +66,9 @@ export class JigsawSliderHandle implements OnInit{
     public _$handleStyle = {};
 
     private setHandleStyle() {
-        if(isNaN(this._offset)) return;
+        if (isNaN(this._offset)) return;
 
-        if(this._slider.vertical) { // 兼容垂直滑动条;
+        if (this._slider.vertical) { // 兼容垂直滑动条;
             this._$handleStyle = {
                 bottom: this._offset + "%"
             }
@@ -84,17 +87,17 @@ export class JigsawSliderHandle implements OnInit{
         let dimensions = this._slider._dimensions;
 
         // bottom 在dom中的位置.
-        let offset = this._slider.vertical?dimensions.bottom: dimensions.left;
-        let size = this._slider.vertical?dimensions.height: dimensions.width;
-        let posValue = this._slider.vertical? pos.y - 6: pos.x;
+        let offset = this._slider.vertical ? dimensions.bottom : dimensions.left;
+        let size = this._slider.vertical ? dimensions.height : dimensions.width;
+        let posValue = this._slider.vertical ? pos.y - 6 : pos.x;
 
-        if(this._slider.vertical) {
-            posValue = posValue > offset? offset:posValue;
+        if (this._slider.vertical) {
+            posValue = posValue > offset ? offset : posValue;
         } else {
-            posValue = posValue < offset? offset:posValue;
+            posValue = posValue < offset ? offset : posValue;
         }
 
-        let newValue = Math.abs(posValue - offset) / size * (this._slider.max - this._slider.min) + (this._slider.min-0); // 保留两位小数
+        let newValue = Math.abs(posValue - offset) / size * (this._slider.max - this._slider.min) + (this._slider.min - 0); // 保留两位小数
 
         let m = this._calFloat(this._slider.step);
 
@@ -114,7 +117,8 @@ export class JigsawSliderHandle implements OnInit{
         let m = 0;
         try {
             m = this._slider.step.toString().split(".")[1].length;
-        } catch(e) { }
+        } catch (e) {
+        }
         return m;
     }
 
@@ -124,7 +128,7 @@ export class JigsawSliderHandle implements OnInit{
     public _$updateCanDragged(flag: boolean) {
         this._dragged = flag;
 
-        if(flag) {
+        if (flag) {
             this._registerGlobalEvent();
         } else {
             this._destroyGlobalEvent();
@@ -146,14 +150,18 @@ export class JigsawSliderHandle implements OnInit{
     }
 
     _destroyGlobalEvent() {
-        if(this.globalEventMouseMove) { this.globalEventMouseMove(); }
+        if (this.globalEventMouseMove) {
+            this.globalEventMouseMove();
+        }
 
-        if(this.globalEventMouseUp)  { this.globalEventMouseUp(); }
+        if (this.globalEventMouseUp) {
+            this.globalEventMouseUp();
+        }
     }
 
-    private _slider:JigsawSlider; // 父组件;
+    private _slider: JigsawSlider; // 父组件;
 
-    constructor(private _render: Renderer2,@Host() @Inject(forwardRef(() => JigsawSlider)) slider: JigsawSlider) {
+    constructor(private _render: Renderer2, @Host() @Inject(forwardRef(() => JigsawSlider)) slider: JigsawSlider) {
         this._slider = slider;
     }
 
@@ -162,7 +170,7 @@ export class JigsawSliderHandle implements OnInit{
      * @internal
      */
     public _$updateValuePosition(event?) {
-        if(!this._dragged|| this._slider.disabled) return;
+        if (!this._dragged || this._slider.disabled) return;
 
         // 防止产生选中其他文本，造成鼠标放开后还可以拖拽的奇怪现象;
         event.stopPropagation();
@@ -175,7 +183,7 @@ export class JigsawSliderHandle implements OnInit{
 
         let newValue = this.transformPosToValue(pos);
 
-        if(this.value === newValue) return;
+        if (this.value === newValue) return;
 
         this.value = newValue;
 
@@ -197,7 +205,8 @@ export class JigsawSliderHandle implements OnInit{
     selector: 'jigsaw-slider, j-slider',
     templateUrl: './slider.html',
     host: {
-        'class': 'jigsaw-slider-host',
+        '[class.jigsaw-slider-host]': 'true',
+        '[class.jigsaw-slider-vertical]': 'vertical',
         '[style.width]': 'width',
         '[style.height]': 'height'
     },
@@ -412,7 +421,7 @@ export class JigsawSlider extends AbstractJigsawComponent implements ControlValu
         let vertical = this.vertical;
 
         this._marks.forEach(mark => {
-            const richMark:any = {};
+            const richMark: any = {};
             if (vertical) {
                 richMark.dotStyle = {
                     bottom: this._transformValueToPos(mark.value) + "%"
@@ -493,7 +502,8 @@ export class JigsawSlider extends AbstractJigsawComponent implements ControlValu
         }
     }
 
-    private _propagateChange: any = () => {};
+    private _propagateChange: any = () => {
+    };
 
     // ngModel触发的writeValue方法，只会在ngOnInit,ngAfterContentInit,ngAfterViewInit这些生命周期之后才调用
     public writeValue(value: any): void {

--- a/src/jigsaw/component/slider/slider.ts
+++ b/src/jigsaw/component/slider/slider.ts
@@ -79,7 +79,7 @@ export class JigsawSliderHandle implements OnInit {
         }
     }
 
-    private _dragged: boolean = false;
+    private _dragging: boolean = false;
 
     public transformPosToValue(pos) {
         // 更新取得的滑动条尺寸.
@@ -125,14 +125,9 @@ export class JigsawSliderHandle implements OnInit {
     /**
      * @internal
      */
-    public _$updateCanDragged(flag: boolean) {
-        this._dragged = flag;
-
-        if (flag) {
-            this._registerGlobalEvent();
-        } else {
-            this._destroyGlobalEvent();
-        }
+    public _$startToDrag() {
+        this._dragging = true;
+        this._registerGlobalEvent();
     }
 
     globalEventMouseMove: Function;
@@ -143,10 +138,9 @@ export class JigsawSliderHandle implements OnInit {
             this._$updateValuePosition(e);
         });
         this.globalEventMouseUp = this._render.listen("document", "mouseup", () => {
-            this._dragged = false;
+            this._dragging = false;
             this._destroyGlobalEvent();
         });
-
     }
 
     _destroyGlobalEvent() {
@@ -170,7 +164,7 @@ export class JigsawSliderHandle implements OnInit {
      * @internal
      */
     public _$updateValuePosition(event?) {
-        if (!this._dragged || this._slider.disabled) return;
+        if (!this._dragging || this._slider.disabled) return;
 
         // 防止产生选中其他文本，造成鼠标放开后还可以拖拽的奇怪现象;
         event.stopPropagation();


### PR DESCRIPTION
fixes #280 
fixes #283

1. 修改slider在form里面绑定`ngModel`，无法正确显示初始样式
2.优化slider的布局，设置宽高
3.去掉slider多余的绑定事件
4.优化slider的设置value
5.优化slider的demo