### PR TITLE
[修复] 修复group items为空时，在destroy中会报错的问题

### DIFF
--- a/src/jigsaw/component/list-and-tile/group-common.ts
+++ b/src/jigsaw/component/list-and-tile/group-common.ts
@@ -153,7 +153,9 @@ export class AbstractJigsawGroupComponent extends AbstractJigsawComponent implem
         if (this._removeRefreshCallback) {
             this._removeRefreshCallback()
         }
-        this._items.forEach(item => item.change.unsubscribe());
+        if(this._items) {
+            this._items.forEach(item => item.change.unsubscribe());
+        }
     }
 
     protected _propagateChange: any = () => {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15992591/46843931-80745280-ce07-11e8-90bb-e71c815664f0.png)
