### PR TITLE
[故障] 修复table的checkbox渲染器设置初始data会导致功能不可用，fixes #925

### DIFF
--- a/src/app/demo/table/checkbox-column/demo.component.ts
+++ b/src/app/demo/table/checkbox-column/demo.component.ts
@@ -29,7 +29,10 @@ export class TableAddCheckboxColumnDemoComponent {
             renderer: TableHeadCheckboxRenderer,
         },
         cell: {
-            renderer: TableCellCheckboxRenderer
+            renderer: TableCellCheckboxRenderer,
+            data: (td, row, col) => {
+                return td.data[row][2] == 'Developer'
+            }
         }
     }];
 

--- a/src/jigsaw/component/table/table.ts
+++ b/src/jigsaw/component/table/table.ts
@@ -171,6 +171,20 @@ export class JigsawTable extends AbstractJigsawComponent implements OnInit, Afte
         return tableData.data[row][index];
     }
 
+    private _updateAdditionalData(field: string, row: number, cellData: string) {
+        let [index, tableData] = this._getColumnIndex(field);
+        if (index == -1) {
+            console.error('no cell data found, unknown field: ' + field);
+            return;
+        }
+        if (!tableData.data[row]) {
+            tableData.data[row] = [];
+        }
+        if (tableData instanceof AdditionalTableData) {
+            tableData.data[row][index] = cellData;
+        }
+    }
+
     /**
      * @internal
      */
@@ -221,8 +235,10 @@ export class JigsawTable extends AbstractJigsawComponent implements OnInit, Afte
                 const cellDataGenerator = TableUtils.getGenerator(columnDefine, 'data');
                 if (cellDataGenerator) {
                     settings.cellData = cellDataGenerator(this.data, rowIndex, realColIndex, this._additionalData);
+                    this._updateAdditionalData(field, rowIndex, settings.cellData);
                 } else if (columnDefine.cell && typeof columnDefine.cell.data == 'string') {
                     settings.cellData = columnDefine.cell.data;
+                    this._updateAdditionalData(field, rowIndex, settings.cellData);
                 } else {
                     settings.cellData = this._getCellDataByField(field, rowIndex);
                 }


### PR DESCRIPTION
fixes #925