### PR TITLE
[故障] 修复由于ng9组件继承元数据导致autoCompleteInput样式出现问题

### DIFF
--- a/src/jigsaw/pc-components/input/auto-complete-input.ts
+++ b/src/jigsaw/pc-components/input/auto-complete-input.ts
@@ -18,7 +18,7 @@ import {
 import {CommonModule} from "@angular/common";
 import {FormsModule, NG_VALUE_ACCESSOR} from "@angular/forms";
 import {PerfectScrollbarModule} from "ngx-perfect-scrollbar";
-import {JigsawInput, JigsawInputModule} from "./input";
+import {JigsawInput, JigsawInputBase, JigsawInputModule} from "./input";
 import {CommonUtils} from "../../common/core/utils/common-utils";
 import {JigsawFloat, JigsawFloatModule} from "../../common/directive/float/index";
 
@@ -56,7 +56,7 @@ export class DropDownValue {
     ],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class JigsawAutoCompleteInput extends JigsawInput implements OnDestroy, AfterViewInit {
+export class JigsawAutoCompleteInput extends JigsawInputBase implements OnDestroy, AfterViewInit {
     @ViewChild(JigsawFloat)
     private _dropdownFloat: JigsawFloat;
 
@@ -107,9 +107,6 @@ export class JigsawAutoCompleteInput extends JigsawInput implements OnDestroy, A
         [...this._bakData] = this._$data;
     }
 
-    @Input()
-    public valid: boolean = true;
-
     /**
      * 用于控制在输入框获得焦点后是否自动执行过滤
      *
@@ -143,8 +140,8 @@ export class JigsawAutoCompleteInput extends JigsawInput implements OnDestroy, A
     @Output('textSelect')
     public textSelectEvent = new EventEmitter<Event>();
 
-    constructor(protected _zone: NgZone, private _cdr: ChangeDetectorRef) {
-        super(_zone);
+    constructor(protected _cdr: ChangeDetectorRef, protected _zone: NgZone) {
+        super(_cdr, _zone);
     }
 
     ngAfterViewInit() {

--- a/src/jigsaw/pc-components/input/input.ts
+++ b/src/jigsaw/pc-components/input/input.ts
@@ -1,38 +1,17 @@
 import {
-    NgModule, Component, EventEmitter, Input, Output, ElementRef, ViewChild, forwardRef, ChangeDetectionStrategy
+    NgModule, Component, EventEmitter, Input, Output, ElementRef, ViewChild, forwardRef, ChangeDetectionStrategy,
+    Directive, NgZone, ChangeDetectorRef
 } from "@angular/core";
 import {CommonModule} from "@angular/common";
 import {ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR} from "@angular/forms";
 import {AbstractJigsawComponent, IJigsawFormControl} from "../../common/common";
 import {CommonUtils} from "../../common/core/utils/common-utils";
 
-/**
- * 单行输入框组件，常常用于接收用户的文本输入。
- *
- * 支持前后置图标，且每个图标都可交互，[参考demo]($demo=pc/input/icons)。
- *
- * 这是一个表单友好组件。
- *
- * $demo = input/full
- */
-@Component({
-    selector: 'jigsaw-input, j-input',
-    templateUrl: 'input.html',
-    host: {
-        '[style.width]': 'width',
-        '[style.height]': 'height',
-        '(click)': '_$stopPropagation($event)',
-        '[class.jigsaw-input]': 'true',
-        '[class.jigsaw-input-error]': '!valid',
-        '[class.jigsaw-input-focused]': 'focused',
-        '[class.jigsaw-input-disabled]': 'disabled'
-    },
-    providers: [
-        {provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => JigsawInput), multi: true},
-    ],
-    changeDetection: ChangeDetectionStrategy.OnPush
-})
-export class JigsawInput extends AbstractJigsawComponent implements IJigsawFormControl, ControlValueAccessor {
+@Directive()
+export abstract class JigsawInputBase extends AbstractJigsawComponent  implements IJigsawFormControl, ControlValueAccessor {
+    constructor(protected _cdr: ChangeDetectorRef, protected _zone?: NgZone) {
+        super(_zone);
+    }
 
     /**
      * 在文本框里的文本非空时，是否显示快速清除按钮，默认为显示。用户单击了清除按钮时，文本框里的文本立即被清空。
@@ -56,19 +35,6 @@ export class JigsawInput extends AbstractJigsawComponent implements IJigsawFormC
      */
     @Input() public valid: boolean = true;
 
-
-    /**
-     * 当用户设置类型为password时，输入内容隐藏为特殊字符。
-     *
-     * $demo = input/password
-     */
-    @Input() public password: boolean = false;
-
-    @Input()
-    public get type(): string {
-        return this.password ? "password" : "text";
-    }
-
     @Output('focus')
     private _focusEmitter: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
 
@@ -83,6 +49,7 @@ export class JigsawInput extends AbstractJigsawComponent implements IJigsawFormC
             return;
         }
         this._value = value.toString();
+        this._cdr.markForCheck();
     }
 
     public registerOnChange(fn: any): void {
@@ -111,6 +78,7 @@ export class JigsawInput extends AbstractJigsawComponent implements IJigsawFormC
         this._value = newValue;
         this.valueChange.emit(this._value);
         this._propagateChange(this._value);
+        this._cdr.markForCheck();
     }
 
     /**
@@ -137,40 +105,7 @@ export class JigsawInput extends AbstractJigsawComponent implements IJigsawFormC
         return this._placeholder;
     }
 
-
-    @ViewChild('input')
-    private _inputElement: ElementRef;
-
-    /**
-     * 调用此方法可以通过编程方式使得文本获得焦点。
-     * 当确信用户需要在文本框中输入时，自动让文本框获得焦点可以提升体验。
-     *
-     * $demo = input/focus
-     */
-    public focus() {
-        this._focused = true;
-        this._inputElement.nativeElement.focus();
-    }
-
-    /**
-     * 调用此方法可以通过编程方式选中文本框中的所有文本。
-     * 当确信用户需要修改文本框里的文本时，自动选中所有文本可以提升体验。
-     *
-     * $demo = input/select
-     */
-    public select() {
-        this._inputElement.nativeElement.select();
-    }
-
-    /**
-     * @internal
-     */
-    public _$clearValue(): void {
-        this.value = '';
-        this.focus();
-    }
-
-    private _focused: boolean = false;
+    protected _focused: boolean = false;
 
     /**
      * 获取文本框是否有焦点
@@ -214,6 +149,82 @@ export class JigsawInput extends AbstractJigsawComponent implements IJigsawFormC
                 }
             }, 150);
         }
+    }
+}
+
+/**
+ * 单行输入框组件，常常用于接收用户的文本输入。
+ *
+ * 支持前后置图标，且每个图标都可交互，[参考demo]($demo=pc/input/icons)。
+ *
+ * 这是一个表单友好组件。
+ *
+ * $demo = input/full
+ */
+@Component({
+    selector: 'jigsaw-input, j-input',
+    templateUrl: 'input.html',
+    host: {
+        '[style.width]': 'width',
+        '[style.height]': 'height',
+        '(click)': '_$stopPropagation($event)',
+        '[class.jigsaw-input]': 'true',
+        '[class.jigsaw-input-error]': '!valid',
+        '[class.jigsaw-input-focused]': 'focused',
+        '[class.jigsaw-input-disabled]': 'disabled'
+    },
+    providers: [
+        {provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => JigsawInput), multi: true},
+    ],
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class JigsawInput extends JigsawInputBase {
+    constructor(protected _cdr: ChangeDetectorRef) {
+        super(_cdr);
+    }
+
+    /**
+     * 当用户设置类型为password时，输入内容隐藏为特殊字符。
+     *
+     * $demo = input/password
+     */
+    @Input() public password: boolean = false;
+
+    @Input()
+    public get type(): string {
+        return this.password ? "password" : "text";
+    }
+
+    @ViewChild('input')
+    private _inputElement: ElementRef;
+
+    /**
+     * 调用此方法可以通过编程方式使得文本获得焦点。
+     * 当确信用户需要在文本框中输入时，自动让文本框获得焦点可以提升体验。
+     *
+     * $demo = input/focus
+     */
+    public focus() {
+        this._focused = true;
+        this._inputElement.nativeElement.focus();
+    }
+
+    /**
+     * 调用此方法可以通过编程方式选中文本框中的所有文本。
+     * 当确信用户需要修改文本框里的文本时，自动选中所有文本可以提升体验。
+     *
+     * $demo = input/select
+     */
+    public select() {
+        this._inputElement.nativeElement.select();
+    }
+
+    /**
+     * @internal
+     */
+    public _$clearValue(): void {
+        this.value = '';
+        this.focus();
     }
 
     /**


### PR DESCRIPTION
这边发现了ng9的一个破坏性，就是一个组件被另一个组件继承，他的元数据即@Component也会被继承，这里的autoCompleteInput就是继承了JigsawInput的host绑定导致样式问题

autoCompleteInput本来就不应该继承JigsawInput，因为他内部有一个JigsawInput，我写一个JigsawInputBase来收集他们的公共属性