### PR TITLE
[故障] 修复没有初始值gr为分钟或小时，选了日期后value值依旧为00:00:00

### DIFF
--- a/src/jigsaw/pc-components/date-and-time/date-time-picker.ts
+++ b/src/jigsaw/pc-components/date-and-time/date-time-picker.ts
@@ -368,15 +368,15 @@ export class JigsawDateTimePicker extends AbstractJigsawComponent implements Con
     }
 
     private _getDefaultLimitStart() {
-        return this.gr == TimeGr.hour ? '00' : this.gr == TimeGr.time_hour_minute ? '00:00' : '00:00:00';
+        return this.gr == TimeGr.hour ? '00' : this.gr == TimeGr.minute ? '00:00' : '00:00:00';
     }
 
     private _getDefaultLimitEnd() {
-        return this.gr == TimeGr.hour ? '23' : this.gr == TimeGr.time_hour_minute ? '23:59' : '23:59:59';
+        return this.gr == TimeGr.hour ? '23' : this.gr == TimeGr.minute ? '23:59' : '23:59:59';
     }
 
     private _getDefaultTime() {
-        return this.gr == TimeGr.hour ? '00' : this.gr == TimeGr.time_hour_minute ? '00:00' : '00:00:00';
+        return this.gr == TimeGr.hour ? '00' : this.gr == TimeGr.minute ? '00:00' : '00:00:00';
     }
 
     private _isDateSame(date1, date2) {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/15992591/85269069-f3bddb00-b4a9-11ea-9e4e-79c4cdd29884.png)

