### PR TITLE
[故障] 修复导航菜单在设置showToggleButton=false和collapsed=true时的宽度问题，解决了@1250

### DIFF
--- a/src/jigsaw/pc-components/menu/navigation-menu.ts
+++ b/src/jigsaw/pc-components/menu/navigation-menu.ts
@@ -20,7 +20,7 @@ type PopupAnswer = {
     host: {
         '[class.jigsaw-nav-menu]': 'true',
         '[style.height]': 'height',
-        '[style.width]': 'collapsed ? null : width'
+        '[style.width]': 'showToggleButton && collapsed ? null : width'
     },
     animations: [collapseMotion],
     changeDetection: ChangeDetectionStrategy.OnPush


### PR DESCRIPTION
fixes #1250 