### PR TITLE
表格拖拽单元格渲染器问题修复

### DIFF
--- a/src/jigsaw/pc-components/table/table-renderer.ts
+++ b/src/jigsaw/pc-components/table/table-renderer.ts
@@ -615,7 +615,7 @@ export class TreeTableCellRenderer extends TableCellRendererBase {
                 (jigsawDrop)="_$dropHandle($event)">
             </span>
             <span class="drop-mid"
-                jigsaw-droppable [title]="_$title"
+                jigsaw-droppable
                 (jigsawDragEnter)="_$dragEnterHandle($event)"
                 (jigsawDrop)="_$dropHandle($event)">
                 <i [class]="_$icon"></i>


### PR DESCRIPTION
Change-Id: I048e7e9a9acf76f0592595715ac969e1f62790bb

原本渲染器内的title功能会干扰Awade中通用的title配置，故去除。