### PR TITLE
[修复] ButtonBar组件长文本可正常显示省略号；左右两侧留白依照规范改为16px；

### DIFF
--- a/src/jigsaw/pc-components/list-and-tile/tile.scss
+++ b/src/jigsaw/pc-components/list-and-tile/tile.scss
@@ -90,7 +90,7 @@ $button-bar-prefix-cls: #{$jigsaw-prefix}-button-bar;
         width: auto;
         min-width: 60px;
         margin: 0;
-        padding: 0 2px;
+        padding: 0 16px;
         border-radius: 0;
 
         &:first-child {

--- a/src/jigsaw/pc-components/list-and-tile/tile.scss
+++ b/src/jigsaw/pc-components/list-and-tile/tile.scss
@@ -90,7 +90,7 @@ $button-bar-prefix-cls: #{$jigsaw-prefix}-button-bar;
         width: auto;
         min-width: 60px;
         margin: 0;
-        padding: 0;
+        padding: 0 2px;
         border-radius: 0;
 
         &:first-child {
@@ -111,6 +111,9 @@ $button-bar-prefix-cls: #{$jigsaw-prefix}-button-bar;
 
         & > p {
             margin-left: 3px;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow: hidden;
         }
     }
 

--- a/src/jigsaw/pc-components/list-and-tile/tile.scss
+++ b/src/jigsaw/pc-components/list-and-tile/tile.scss
@@ -90,7 +90,7 @@ $button-bar-prefix-cls: #{$jigsaw-prefix}-button-bar;
         width: auto;
         min-width: 60px;
         margin: 0;
-        padding: 0 16px;
+        padding: 0 8px;
         border-radius: 0;
 
         &:first-child {


### PR DESCRIPTION
Change-Id: I060926188e7a79b0076be7c3e3b00270164828cd