### PR TITLE
[修复]取消draw组件的手柄阴影

### DIFF
--- a/src/jigsaw/pc-components/drawer/drawer.scss
+++ b/src/jigsaw/pc-components/drawer/drawer.scss
@@ -5,7 +5,7 @@ $drawer-prefix-cls: #{$jigsaw-prefix}-drawer;
 .#{$drawer-prefix-cls} {
     background: $bg-component;
     box-shadow: $box-shadow-lv2;
-    z-index: $zindex-popover-level-0;
+    z-index: $zindex-popover-level-1;
     &-in-dom {
         position: relative;
         display: inline-block;
@@ -43,9 +43,8 @@ $drawer-prefix-cls: #{$jigsaw-prefix}-drawer;
         text-align: center;
         color: $font-color-white;
         background: $brand-default;
-        cursor: pointer;
         border-radius: 0 $border-radius-base $border-radius-base 0;
-        box-shadow: $box-shadow-lv2;
+        cursor: pointer;
 
         .iconfont {
             font-size: $icon-size-sm;


### PR DESCRIPTION
Change-Id: Ic5a0e628e0c9788757b75c1fc103fd270df8f55f
- 查看了设计稿，手柄是没有阴影的。