### PR TITLE
[修复] range-time当前日期的右侧日期框可正常显示

### DIFF
--- a/src/jigsaw/pc-components/date-and-time/date-picker.scss
+++ b/src/jigsaw/pc-components/date-and-time/date-picker.scss
@@ -194,6 +194,7 @@ $date-prefix-cls: #{$jigsaw-prefix}-date-picker;
                 border-style: solid;
                 border-color: $brand-default;
                 border-radius: $border-radius-sm;
+                z-index: $zindex-popover-level-1;
             }
 
             &-prev-next span {

--- a/src/jigsaw/pc-components/date-and-time/date-picker.scss
+++ b/src/jigsaw/pc-components/date-and-time/date-picker.scss
@@ -159,11 +159,10 @@ $date-prefix-cls: #{$jigsaw-prefix}-date-picker;
         }
 
         &-day-cell {
+            position: relative;
             display: flex;
             justify-content: center;
             align-items: center;
-            position: relative;
-            box-sizing: border-box;
 
             span {
                 display: inline-flex;
@@ -194,6 +193,7 @@ $date-prefix-cls: #{$jigsaw-prefix}-date-picker;
                 border-style: solid;
                 border-color: $brand-default;
                 border-radius: $border-radius-sm;
+                box-sizing: border-box;
                 z-index: $zindex-popover-level-1;
             }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41236821/108449153-f9b8c580-729d-11eb-9671-9fc343592969.png)
