### PR TITLE
[修复] 表格列头用图标时，图标与文本对垂直居中

### DIFF
--- a/src/jigsaw/pc-components/table/table.scss
+++ b/src/jigsaw/pc-components/table/table.scss
@@ -23,6 +23,21 @@ $table-prefix-cls: #{$jigsaw-prefix}-table;
                 td {
                     height: 40px;
                     background: $bg-header;
+                    
+                    .#{$table-prefix-cls}-header-cell{
+                        display: inline-flex;
+                        justify-content: center;
+                        align-items: center;
+                        width: 100%;
+
+                        .iconfont{
+                            margin-right: 2px;
+                        }
+
+                        ng-component{
+                            width: 100%;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Change-Id: Idbf79f910ea59537144e50bb1389850a597198a8
![image](https://user-images.githubusercontent.com/41236821/108469146-b91f7300-72c2-11eb-9aa3-a962865142d2.png)
![image](https://user-images.githubusercontent.com/41236821/108469184-c5a3cb80-72c2-11eb-853e-3d7489dc3635.png)
