### PR TITLE
[优化] Breadcrumb组件文字底端对齐；各主题下字体颜色与规范对齐；

### DIFF
--- a/src/app/demo/pc/breadcrumb/demo-set.module.ts
+++ b/src/app/demo/pc/breadcrumb/demo-set.module.ts
@@ -11,6 +11,8 @@ import { BreadcrumbHintDemoComponent } from "./hints/demo.component";
 import { BreadcrumbHintDemoModule } from "./hints/demo.module"
 import { BreadcrumbFoldDemoComponent } from "./fold/demo.component";
 import { BreadcrumbFoldDemoModule } from "./fold/demo.module"
+import { BreadcrumbModeDemoComponent } from './mode/demo.component';
+import { BreadcrumbModeDemoModule } from './mode/demo.module';
 
 export const routerConfig = [
     {
@@ -35,6 +37,9 @@ export const routerConfig = [
                 path: 'buy/:id', component: BreadcrumbRouterBuy
             }
         ]
+    },
+    {
+        path: 'theme', component: BreadcrumbModeDemoComponent
     }
 ];
 
@@ -44,7 +49,8 @@ export const routerConfig = [
         BreadcrumbBasicDemoModule,
         BreadcrumbHintDemoModule,
         BreadcrumbFoldDemoModule,
-        BreadcrumbRouterDemoModule
+        BreadcrumbRouterDemoModule,
+        BreadcrumbModeDemoModule
     ]
 })
 export class BreadcrumbDemoModule {

--- a/src/app/demo/pc/breadcrumb/fold/demo.component.ts
+++ b/src/app/demo/pc/breadcrumb/fold/demo.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from "@angular/core";
+import { Component } from "@angular/core";
 import { BreadcrumbNode } from "jigsaw/public_api";
 
 @Component({

--- a/src/app/demo/pc/breadcrumb/mode/demo.component.html
+++ b/src/app/demo/pc/breadcrumb/mode/demo.component.html
@@ -1,0 +1,15 @@
+<!-- ignore the following lines, they are not important to this demo -->
+<jigsaw-demo-description [summary]="summary" [content]="description">
+</jigsaw-demo-description>
+
+<!-- start to learn the demo from here -->
+<jigsaw-header>明亮主题</jigsaw-header>
+<j-breadcrumb [data]="data" theme="light" (select)="itemSelect($event)"></j-breadcrumb>
+
+<jigsaw-header>深色主题</jigsaw-header>
+<j-breadcrumb [data]="data" theme="dark" (select)="itemSelect($event)"></j-breadcrumb>
+
+<jigsaw-header>内嵌主题</jigsaw-header>
+<j-breadcrumb [data]="data" theme="inner" (select)="itemSelect($event)"></j-breadcrumb>
+
+<a (click)="resetBreadcrumbItems()">数据重置</a>

--- a/src/app/demo/pc/breadcrumb/mode/demo.component.scss
+++ b/src/app/demo/pc/breadcrumb/mode/demo.component.scss
@@ -1,0 +1,3 @@
+jigsaw-header:not(:first-of-type) {
+    margin-top: 20px;
+}

--- a/src/app/demo/pc/breadcrumb/mode/demo.component.ts
+++ b/src/app/demo/pc/breadcrumb/mode/demo.component.ts
@@ -1,0 +1,40 @@
+import { Component } from "@angular/core";
+import { BreadcrumbNode } from "jigsaw/public_api";
+
+@Component({
+    templateUrl: "./demo.component.html",
+    styleUrls: ["./demo.component.scss"]
+})
+export class BreadcrumbModeDemoComponent {
+    public data: (string | BreadcrumbNode)[];
+
+    constructor() {
+        this.resetBreadcrumbItems();
+    }
+
+    public itemSelect(item: BreadcrumbNode) {
+        console.log("当前点击的节点是：", item);
+        const idx = this.data.findIndex(i => item === i);
+        this.data = this.data.slice(0, idx + 1);
+    }
+
+    public resetBreadcrumbItems() {
+        this.data = [
+            { label: "主页", icon: "iconfont iconfont-e647" },
+            // 当节点只有文本时，也可以直接给字符串，这样更便捷
+            "业务管理",
+            "业务清单-1",
+            "业务清单-2",
+            "业务清单-3",
+            // 也支持label属性
+            { label: "业务样本" }
+        ];
+    }
+
+    // ====================================================================
+    // ignore the following lines, they are not important to this demo
+    // ====================================================================
+    summary: string = "面包屑的标签数超过指定数目时进行折叠";
+    description: string =
+        "在组件标签内设置foldThreshold的值，控制面包屑的折叠。一旦面包屑的标签数超过设定的值，会进行折叠。";
+}

--- a/src/app/demo/pc/breadcrumb/mode/demo.module.ts
+++ b/src/app/demo/pc/breadcrumb/mode/demo.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { JigsawBreadcrumbModule, JigsawHeaderModule } from "jigsaw/public_api";
+import { JigsawDemoDescriptionModule } from "app/demo-description/demo-description";
+import { BreadcrumbModeDemoComponent } from "./demo.component";
+
+@NgModule({
+    declarations: [BreadcrumbModeDemoComponent],
+    exports: [BreadcrumbModeDemoComponent],
+    imports: [CommonModule, JigsawBreadcrumbModule, JigsawDemoDescriptionModule, JigsawHeaderModule]
+})
+export class BreadcrumbModeDemoModule {}

--- a/src/jigsaw/common/core/theming/prebuilt/settings/paletx-pro-dark.scss
+++ b/src/jigsaw/common/core/theming/prebuilt/settings/paletx-pro-dark.scss
@@ -238,6 +238,7 @@ $font-color-heading: $gray-10;
 $font-color-heading-bold: $gray-9;
 $font-color-tag: $gray-8;
 $font-color-white: hsl(0, 0%, 100%);
+$font-color-white-dark: $gray-6;
 
 /* border 边框 */
 $border-color-default: $gray-6;

--- a/src/jigsaw/common/core/theming/prebuilt/settings/paletx-pro-light.scss
+++ b/src/jigsaw/common/core/theming/prebuilt/settings/paletx-pro-light.scss
@@ -240,6 +240,7 @@ $font-color-heading: $gray-10;
 $font-color-heading-bold: $gray-9;
 $font-color-tag: $gray-8;
 $font-color-white: hsl(0, 0%, 100%);
+$font-color-white-dark: $gray-6;
 
 /* border 边框 */
 $border-color-default: $gray-5;

--- a/src/jigsaw/pc-components/breadcrumb/breadcrumb.scss
+++ b/src/jigsaw/pc-components/breadcrumb/breadcrumb.scss
@@ -34,7 +34,8 @@ $bc-prefix-cls: #{$jigsaw-prefix}-breadcrumb;
         display: inline-flex;
         justify-content: center;
         align-items: center;
-        margin: 0 8px;
+        margin: 0 2px;
+        font-size: $icon-size-sm;
         color: $font-color-watermark;
     }
 
@@ -53,11 +54,16 @@ $bc-prefix-cls: #{$jigsaw-prefix}-breadcrumb;
 
     &.#{$bc-prefix-cls}-light {
         background: $bg-container;
+        font-size: $font-title-med;
         .#{$bc-prefix-cls}-item {
             height: $height-sm;
             color: $brand-default;
+            font-size: $font-size-lg;
+            &:hover{
+                color: $brand-hover;
+            }
             &.#{$bc-prefix-cls}-current {
-                font-size: $font-title-lg;
+                font-size: $font-title-med;
                 font-weight: bold;
                 color: $font-color-heading-bold;
             }
@@ -66,10 +72,16 @@ $bc-prefix-cls: #{$jigsaw-prefix}-breadcrumb;
 
     &.#{$bc-prefix-cls}-dark {
         background: $bg-body-dark;
+        font-size: $font-title-med;
         .#{$bc-prefix-cls}-item {
-            color: $font-color-white;
+            color: $font-color-white-dark;
+            font-size: $font-size-lg;
+            &:hover {
+                color: $font-color-white;
+            }
             &.#{$bc-prefix-cls}-current {
-                font-size: $font-title-lg;
+                font-size: $font-title-med;
+                font-weight: bold;
                 color: $font-color-white;
             }
         }
@@ -94,6 +106,7 @@ $bc-prefix-cls: #{$jigsaw-prefix}-breadcrumb;
                 font-size: $font-title-lg;
                 font-weight: bold;
                 color: $font-color-heading-bold;
+                padding-bottom: 4px;
                 .#{$bc-prefix-cls}-icon {
                     color: $font-color-heading-bold;
                 }

--- a/src/jigsaw/pc-components/header/header.scss
+++ b/src/jigsaw/pc-components/header/header.scss
@@ -3,6 +3,7 @@
 $header-prefix-cls: #{$jigsaw-prefix}-header;
 
 .#{$header-prefix-cls}-host {
+    display: flex;
     &.#{$header-prefix-cls}-level-1 {
         .#{$header-prefix-cls}-content {
             display: flex;


### PR DESCRIPTION
Change-Id: I089ba4b580e61902a58cf93e27cecb8f1135d056

https://gitlab.zte.com.cn/10045812/ng-eval/issues/2527