### PR TITLE
[修复] Menu组件dark模式下disabled字体颜色变灰

### DIFF
--- a/src/jigsaw/pc-components/menu/menu.scss
+++ b/src/jigsaw/pc-components/menu/menu.scss
@@ -31,7 +31,7 @@ $menu-prefix-cls: #{$jigsaw-prefix}-menu;
             &.#{$list-option-prefix-cls}-disabled {
                 background: #102331;
 
-                .menu-list-title {
+                .#{$menu-prefix-cls}-list-title {
                     float: left;
                     line-height: 32px;
                     color: #666666;
@@ -367,5 +367,3 @@ $menu-prefix-cls: #{$jigsaw-prefix}-menu;
         }
     }
 }
-
-


### PR DESCRIPTION
Change-Id: I6f370c15706791881bb2dba42fe7294c24560487

![image](https://user-images.githubusercontent.com/41236821/113265535-d6565100-9306-11eb-81e8-504623875859.png)
https://gitlab.zte.com.cn/10045812/ng-eval/issues/2555