### PR TITLE
[修复] 解决导航菜单在折叠起来的时候，图标没有水平居中的问题，解决了@7274

### DIFF
--- a/src/jigsaw/pc-components/menu/navigation-menu.scss
+++ b/src/jigsaw/pc-components/menu/navigation-menu.scss
@@ -25,14 +25,14 @@ $nav-menu-prefix-cls: #{$jigsaw-prefix}-nav-menu;
                 display: flex;
                 align-items: center;
                 position: relative;
-                padding-left: 16px;
+                padding-left: 14px;
                 font-size: $font-size-lg;
                 font-weight: 400;
                 height: $height-huge;
                 cursor: pointer;
 
                 i {
-                    margin-right: 8px;
+                    margin-right: 10px;
                     width: 14px;
                     text-align: center;
                 }
@@ -69,7 +69,7 @@ $nav-menu-prefix-cls: #{$jigsaw-prefix}-nav-menu;
                     cursor: pointer;
 
                     i {
-                        margin-right: 8px;
+                        margin-right: 10px;
                         width: 14px;
                         text-align: center;
                     }
@@ -85,7 +85,7 @@ $nav-menu-prefix-cls: #{$jigsaw-prefix}-nav-menu;
 
                     &.#{$nav-menu-prefix-cls}-sub-item-collapsed {
                         width: 40px !important;
-                        padding-left: 16px;
+                        padding-left: 14px;
 
                         span {
                             display: none;


### PR DESCRIPTION
Change-Id: Ided47bbb746063a8d414fc44e243ad15c87b8bb0
![image](https://user-images.githubusercontent.com/41236821/120436051-05de1400-c3b1-11eb-94d1-82be90d6c68a.png)
