### PR TITLE
[修复] 解决标题或者内容比较长时，会跟关闭按钮有重叠，解决了@7273

### DIFF
--- a/src/jigsaw/pc-components/notification/notification.scss
+++ b/src/jigsaw/pc-components/notification/notification.scss
@@ -55,9 +55,11 @@
                 font-size: $font-title-med;
                 color: $font-color-heading;
                 margin-bottom: 6px;
+                padding-right: 8px;
             }
 
             .jigsaw-notification-message {
+                padding-right: 8px;
                 word-wrap: break-word;
                 font-size: $font-size-base;
                 color: $font-color-tag;


### PR DESCRIPTION
Change-Id: Ied34a628588909d674d24829d7073f0a408f2550
![image](https://user-images.githubusercontent.com/41236821/120446635-5018c280-c3bc-11eb-9db2-d3dea2034741.png)
