### PR TITLE
[故障] time组件弹出选择时分秒使用上下键盘加减时间的位置不对，解决了@7309

### DIFF
--- a/src/jigsaw/pc-components/date-and-time/time-picker.ts
+++ b/src/jigsaw/pc-components/date-and-time/time-picker.ts
@@ -463,9 +463,9 @@ export class JigsawTimePicker extends AbstractJigsawComponent implements Control
         } else if ($event.keyCode == 37) {
             this._$handleCtrlBarClick($event, -1);
         } else if ($event.keyCode == 40) {
-            this._$handleCtrlBarClick($event, this.step == 1 ? 10 : 1);
+            this._$handleCtrlBarClick($event, this.step == 1 ? 9 : 1);
         } else if ($event.keyCode == 38) {
-            this._$handleCtrlBarClick($event, this.step == 1 ? -10 : -1);
+            this._$handleCtrlBarClick($event, this.step == 1 ? -9 : -1);
         } else if ($event.keyCode == 9) {
             if ($event.shiftKey) {
                 if (this._$selectMode == 'second') {


### PR DESCRIPTION
Change-Id: Ief646c7ca43f80659722fe26d70e222f9af48914