### PR TITLE
[故障] 修复穿梭框右边列表第一次搜索不会及时更新列表，解决了@7325

### DIFF
--- a/src/jigsaw/pc-components/transfer/transfer.ts
+++ b/src/jigsaw/pc-components/transfer/transfer.ts
@@ -457,6 +457,7 @@ export class JigsawTransferInternalList extends AbstractJigsawGroupLiteComponent
                     this.selectedItems = this.selectedItems.concat();
                     this._$updateCurrentPageSelectedItems();
                 }
+                this._cdr.markForCheck();
             });
             this._data.refresh();
             this._cdr.detectChanges();


### PR DESCRIPTION
Change-Id: Ib591e68fca1f08d75b4eb07116e1540576519c72