### PR TITLE
[修复] 解决pagination下拉框文字垂直布局中问题，解决了@7317，@7245

### DIFF
--- a/src/jigsaw/pc-components/pagination/pagination.scss
+++ b/src/jigsaw/pc-components/pagination/pagination.scss
@@ -110,6 +110,10 @@ $jigsaw-input: #{$jigsaw-prefix}-input;
                         padding: 0;
                         min-height: unset;
                         height: 100%;
+
+                        .#{$jigsaw-prefix}-tag-host {
+                            margin: 0;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Change-Id: Icc6f1d3ff8c375a75978591a22788e954695d63f
![image](https://user-images.githubusercontent.com/41236821/122169940-9720b080-ceb0-11eb-843f-b287dbb3fb80.png)
