### PR TITLE
[故障] 修复下拉多选设置宽度时选项文本太长被截掉，解决了@7218

### DIFF
--- a/src/app/demo/pc/select/size/demo.component.html
+++ b/src/app/demo/pc/select/size/demo.component.html
@@ -15,7 +15,7 @@
     <div class="live-demo">
         <h3>多选设置尺寸</h3>
         <p class="comment">多选用minWidth和maxWidth</p>
-        <jigsaw-select minWidth="120"  [data]="cityListForSelect" [multipleSelect]="true" [useStatistics]="false">
+        <jigsaw-select minWidth="120" maxWidth="250" [data]="cityListForSelect" [multipleSelect]="true" [useStatistics]="false">
         </jigsaw-select>
     </div>
     <div class="live-demo">

--- a/src/app/demo/pc/select/size/demo.component.html
+++ b/src/app/demo/pc/select/size/demo.component.html
@@ -15,7 +15,7 @@
     <div class="live-demo">
         <h3>多选设置尺寸</h3>
         <p class="comment">多选用minWidth和maxWidth</p>
-        <jigsaw-select minWidth="120" maxWidth="250" [data]="cityListForSelect" [multipleSelect]="true" [useStatistics]="false">
+        <jigsaw-select minWidth="120"  [data]="cityListForSelect" [multipleSelect]="true" [useStatistics]="false">
         </jigsaw-select>
     </div>
     <div class="live-demo">

--- a/src/jigsaw/pc-components/select/select.scss
+++ b/src/jigsaw/pc-components/select/select.scss
@@ -47,6 +47,14 @@ $jigsaw-list-option: #{$jigsaw-prefix}-list-option;
             }
         }
 
+        &.#{$select-prefix-cls}-with-max-width {
+            .#{$jigsaw-combo-select}-host {
+                .#{$jigsaw-tag}-host {
+                    max-width: 100%;
+                }
+            }
+        }
+
         &.#{$select-prefix-cls}-show-statistics {
             .#{$jigsaw-combo-select} {
                 .#{$jigsaw-combo-select}-selection {

--- a/src/jigsaw/pc-components/select/select.ts
+++ b/src/jigsaw/pc-components/select/select.ts
@@ -30,6 +30,7 @@ import { JigsawSelectBase } from "./select-base";
         "[class.jigsaw-select-single-select]": "!multipleSelect",
         "[class.jigsaw-select-multiple-select]": "multipleSelect",
         "[class.jigsaw-select-show-statistics]": "useStatistics",
+        "[class.jigsaw-select-with-max-width]": "!!maxWidth",
         "[style.min-width]": 'multipleSelect ? minWidth : "none"',
         "[style.max-width]": 'multipleSelect ? maxWidth : "none"',
         "[style.width]": '!multipleSelect ? width : "none"'


### PR DESCRIPTION
Change-Id: I684ce389e8a0d3dc6ea5de9eea69e2d31c0ba2b5