### PR TITLE
[优化] 优化了tooltip文字过长时会超出的问题，解决了@7184

### DIFF
--- a/src/jigsaw/common/directive/tooltip/tooltip.scss
+++ b/src/jigsaw/common/directive/tooltip/tooltip.scss
@@ -1,6 +1,16 @@
 $tooltip-prefix-cls: #{$jigsaw-prefix}-tooltip;
 
 .#{$tooltip-prefix-cls} {
+    $maxLineNum: 5;
     padding: 12px;
     max-width: 400px;
+    > div {
+        display: -webkit-box;
+        word-break: break-all;
+        white-space:pre-wrap;
+        text-overflow: ellipsis;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: $maxLineNum;
+        overflow: hidden;
+    }
 }


### PR DESCRIPTION
Change-Id: I30d309230facc01d5cc8b2903709796de0c2ee30
![image](https://user-images.githubusercontent.com/41236821/123500030-98e73280-d66d-11eb-8838-c3155e94aecc.png)
