### PR TITLE
[修复] 解决list-lite 组件文本垂直不居中的问题，解决了@7199

### DIFF
--- a/src/jigsaw/pc-components/list-and-tile/list-option.scss
+++ b/src/jigsaw/pc-components/list-and-tile/list-option.scss
@@ -5,7 +5,7 @@ $list-option-prefix-cls: #{$jigsaw-prefix}-list-option;
     position: relative;
     width: 100%;
     min-height: $height-base;
-    padding: 5px 8px;
+    padding: 7px 8px;
     cursor: pointer;
     box-sizing: border-box;
     background: $bg-body;


### PR DESCRIPTION
Change-Id: I69a04c75089202bcec45d402739aeb5ecc0a36d7

![image](https://user-images.githubusercontent.com/41236821/123631613-89bcdc00-d849-11eb-91c0-66a773961a43.png)
