### PR TITLE
[优化] 导航菜单折叠时，图标的tooltip出现在右侧，解决了@7034

### DIFF
--- a/src/jigsaw/pc-components/menu/navigation-menu.html
+++ b/src/jigsaw/pc-components/menu/navigation-menu.html
@@ -7,7 +7,7 @@
             <div class="jigsaw-nav-menu-item-top" (click)="_$menuSelect(menuItem)" [ngClass]="{'jigsaw-nav-menu-item-selected': menuItem.selected && menuItem?.nodes?.length > 0,
                  'jigsaw-nav-menu-item-selected-top': menuItem.selected && menuItem?.nodes?.length == 0}">
                 <i *ngIf="collapsed" [ngClass]="menuItem.icon || 'iconfont iconfont-e231'" [jigsawTooltip]="menuItem.label"
-                    jigsawTooltipPosition="bottomRight"></i>
+                    jigsawTooltipPosition="right"></i>
                 <i *ngIf="!collapsed" [ngClass]="menuItem.icon || 'iconfont iconfont-e231'"></i>
                 <span>{{menuItem.label}}</span>
                 <i *ngIf="menuItem?.nodes?.length > 0 && !collapsed"

--- a/src/jigsaw/pc-components/menu/navigation-menu.html
+++ b/src/jigsaw/pc-components/menu/navigation-menu.html
@@ -18,7 +18,7 @@
                 <div *ngFor="let subMenu of menuItem?.nodes" class="jigsaw-nav-menu-sub-item" [ngClass]="{'jigsaw-nav-menu-sub-item-selected': subMenu.selected,
                                 'jigsaw-nav-menu-sub-item-collapsed': collapsed}" (click)="_$subMenuSelect(subMenu)">
                     <i *ngIf="collapsed" [ngClass]="subMenu.icon || 'iconfont iconfont-e231'" [jigsawTooltip]="subMenu.label"
-                        jigsawTooltipPosition="bottomRight"></i>
+                        jigsawTooltipPosition="right"></i>
                     <i *ngIf="!collapsed" [ngClass]="subMenu.icon || 'iconfont iconfont-e231'"></i>
                     <span>{{subMenu.label}}</span>
                 </div>


### PR DESCRIPTION
Change-Id: If2337366b7d2767223dc477f6a4b9b73e9a2a0aa

![image](https://user-images.githubusercontent.com/41236821/124424789-380cd800-dd9a-11eb-8bed-6b18dd3b1f8b.png)
