### PR TITLE
[故障] 修复树组件设置showIcon为false时依旧能显示图标，并且图标是歪的，解决了@7037

### DIFF
--- a/src/jigsaw/pc-components/tree/tree.scss
+++ b/src/jigsaw/pc-components/tree/tree.scss
@@ -102,6 +102,7 @@
                 font-size: $font-size-lg;
                 color: $icon-color-default;
                 cursor: pointer;
+                overflow: hidden;
             }
 
             &:hover {

--- a/src/jigsaw/pc-components/tree/ztree-types.ts
+++ b/src/jigsaw/pc-components/tree/ztree-types.ts
@@ -22,7 +22,7 @@ export class ZTreeSettingView {
     fontCss?: (id: string, node: any) => boolean | object;
     nameIsHTML?: boolean;
     selectedMulti?: boolean;
-    showIcon?: (id: string, node: any) => boolean | boolean;
+    showIcon?: boolean | ((id: string, node: any) => boolean);
     showLine?: boolean;
     showTitle?: boolean;
     txtSelectedEnable?: boolean;


### PR DESCRIPTION
Change-Id: I7f91418cd884e7c86d166b22ab5af83a5cfd52bb