### PR TITLE
[修复] 修复导航菜单在没有子菜单的时候，会显示一个横线，解决了@7038

### DIFF
--- a/src/jigsaw/pc-components/menu/navigation-menu.scss
+++ b/src/jigsaw/pc-components/menu/navigation-menu.scss
@@ -54,8 +54,13 @@ $nav-menu-prefix-cls: #{$jigsaw-prefix}-nav-menu;
                 overflow: hidden;
 
                 &-actived {
-                    border-top: 1px solid $border-color-default;
-                    border-bottom: 1px solid $border-color-default;
+                    .#{$nav-menu-prefix-cls}-sub-item:first-child {
+                        border-top: 1px solid $border-color-default;
+                    }
+                    
+                    .#{$nav-menu-prefix-cls}-sub-item:last-child {
+                        border-bottom: 1px solid $border-color-default;
+                    }
                 }
 
                 .#{$nav-menu-prefix-cls}-sub-item {


### PR DESCRIPTION
Change-Id: I2389110db02f4e9410de528f1c7feeb84f8d8ad2
![image](https://user-images.githubusercontent.com/41236821/124546720-a5ce0800-de5d-11eb-8a09-a33aed47b8a4.png)
