### PR TITLE
[故障] 修复徽章用字符串数字设置偏移会导致计算错误，解决了@7100

### DIFF
--- a/src/jigsaw/common/directive/badge/badge.ts
+++ b/src/jigsaw/common/directive/badge/badge.ts
@@ -77,6 +77,7 @@ export class JigsawBadgeDirective extends AbstractJigsawViewBase implements Afte
     }
 
     public set jigsawBadgeHorizontalOffset(value: number) {
+        value = Number(value);
         if (this._hOffset == value) {
             return;
         }

--- a/src/jigsaw/pc-components/slider/slider.ts
+++ b/src/jigsaw/pc-components/slider/slider.ts
@@ -351,7 +351,11 @@ export class JigsawSlider extends AbstractJigsawComponent implements ControlValu
     }
 
     public set min(min: number) {
-        this._min = Number(min);
+        min = Number(min);
+        if (isNaN(min)) {
+            return;
+        }
+        this._min = min;
     }
 
     private _max: number = 100;
@@ -367,6 +371,10 @@ export class JigsawSlider extends AbstractJigsawComponent implements ControlValu
     }
 
     public set max(max: number) {
+        max = Number(max);
+        if (isNaN(max)) {
+            return;
+        }
         this._max = Number(max);
     }
 

--- a/src/jigsaw/pc-components/slider/slider.ts
+++ b/src/jigsaw/pc-components/slider/slider.ts
@@ -346,12 +346,12 @@ export class JigsawSlider extends AbstractJigsawComponent implements ControlValu
      * @NoMarkForCheckRequired
      */
     @Input()
-    public get min() {
+    public get min():number {
         return this._min;
     }
 
     public set min(min: number) {
-        this._min = min;
+        this._min = Number(min);
     }
 
     private _max: number = 100;
@@ -362,12 +362,12 @@ export class JigsawSlider extends AbstractJigsawComponent implements ControlValu
      * @NoMarkForCheckRequired
      */
     @Input()
-    public get max() {
+    public get max():number {
         return this._max;
     }
 
     public set max(max: number) {
-        this._max = max;
+        this._max = Number(max);
     }
 
     private _step: number = 1;


### PR DESCRIPTION
Change-Id: I3b4416b258475a46ed79c2e10cde122a35b1744f