### PR TITLE
[优化] 增加dialog标题图标与文字间距，解决了@7203

### DIFF
--- a/src/jigsaw/pc-components/dialog/dialog.scss
+++ b/src/jigsaw/pc-components/dialog/dialog.scss
@@ -48,6 +48,10 @@ $dialog-prefix-cls: #{$jigsaw-prefix}-dialog;
         & > div {
             display: flex;
             align-items: center;
+
+            .iconfont {
+                margin-right: 5px;
+            }
         }
     }
 


### PR DESCRIPTION
Change-Id: I6d8bd76a59ddea143873465b628dfbe727b5daf8

![image](https://user-images.githubusercontent.com/41236821/125606674-4199f93a-e514-4a40-88db-e90cc5f8ad55.png)
