### PR TITLE
[优化] tooltip/moving-tooltip 拖动时有动画干扰，导致tooltip位置错误，解决了@7029

### DIFF
--- a/src/jigsaw/pc-components/button/button.scss
+++ b/src/jigsaw/pc-components/button/button.scss
@@ -31,7 +31,7 @@ $btn-prefix-cls: #{$jigsaw-prefix}-button;
 
     &:hover {
         border-color: $brand-default;
-        @include prefixer(transition, all 0.3s $ease-in-out);
+        @include prefixer(transition, animation 0.3s $ease-in-out);
     }
 
     &:active {


### PR DESCRIPTION
Change-Id: Ia871fe9f6ca4d84250ac9d7824e6cb1f37a36602