### PR TITLE
[修复] tooltip在黑暗模式下对齐颜色规范，解决了@6992

### DIFF
--- a/src/jigsaw/common/directive/tooltip/tooltip.scss
+++ b/src/jigsaw/common/directive/tooltip/tooltip.scss
@@ -4,6 +4,10 @@ $tooltip-prefix-cls: #{$jigsaw-prefix}-tooltip;
     $maxLineNum: 5;
     padding: 12px;
     max-width: 400px;
+    border-radius: $border-radius-sm;
+    background: $bg-body-light !important;
+    color: $font-color-default-light;
+
     > div {
         display: -webkit-box;
         word-break: break-all;


### PR DESCRIPTION
Change-Id: I06d23a797c5be830f2f6144cfe42b2327599fc43
![image](https://user-images.githubusercontent.com/41236821/126762617-f7a7724c-d18f-4fc9-9a99-9a923d5043b4.png)
