### PR TITLE
[修复] 解决了Tree组件在数据更新时图标不更新的问题、解决了树字体颜色不变红的问题，解决了@6980，@6990

### DIFF
--- a/src/jigsaw/pc-components/tree/tree-ext.ts
+++ b/src/jigsaw/pc-components/tree/tree-ext.ts
@@ -161,6 +161,7 @@ export class JigsawTreeExt extends AbstractJigsawComponent implements AfterViewI
         );
         sheet.insertRule(
             `.ztree#${this._$uniqueId} li span.button.switch.noline_open::after,
+            .ztree#${this._$uniqueId} li span.button.switch.root_open::after,
             .ztree#${this._$uniqueId} li span.button.switch.roots_open::after,
             .ztree#${this._$uniqueId} li span.button.switch.center_open::after,
             .ztree#${this._$uniqueId} li span.button.switch.bottom_open::after {content: "\\${iconData.nodeOpen}"}`,
@@ -168,6 +169,7 @@ export class JigsawTreeExt extends AbstractJigsawComponent implements AfterViewI
         );
         sheet.insertRule(
             `.ztree#${this._$uniqueId} li span.button.switch.noline_close::after,
+            .ztree#${this._$uniqueId} li span.button.switch.root_close::after,
             .ztree#${this._$uniqueId} li span.button.switch.roots_close::after,
             .ztree#${this._$uniqueId} li span.button.switch.center_close::after,
             .ztree#${this._$uniqueId} li span.button.switch.bottom_close::after {content: "\\${iconData.nodeClose}"}`,
@@ -287,6 +289,7 @@ export class JigsawTreeExt extends AbstractJigsawComponent implements AfterViewI
             return;
         }
         this.ztree = $.fn.zTree.init($("#" + this._$uniqueId), this._setting, this.data.nodes);
+        this._setZTreeIcon()
     }
 
     public selectNodes(key: string, value: any, parentNode: any) {

--- a/src/jigsaw/pc-components/tree/tree.scss
+++ b/src/jigsaw/pc-components/tree/tree.scss
@@ -12,6 +12,8 @@
         &.chk.checkbox_true_full_focus,
         &.switch.noline_open,
         &.switch.noline_close,
+        &.switch.root_open,
+        &.switch.root_close,
         &.switch.roots_open,
         &.switch.roots_close,
         &.switch.center_open,

--- a/src/jigsaw/pc-components/tree/tree.scss
+++ b/src/jigsaw/pc-components/tree/tree.scss
@@ -1,4 +1,4 @@
-.ztree li span {
+.ztree li span:not(.node_name) {
     color: $font-color-default;
     &.button {
         &.edit,
@@ -59,7 +59,9 @@
         }
     }
 }
+
 .ztree li a {
+    color: $font-color-default;
     &:hover {
         background: $bg-hover;
         .node_name {


### PR DESCRIPTION
Change-Id: I6d727219edcef14c3f8444e8e88aeae528d5922f

![image](https://user-images.githubusercontent.com/41236821/127954398-33807811-53d9-45ce-a6b5-a26632cc4429.png)

![image](https://user-images.githubusercontent.com/41236821/127974484-7898fb14-a700-41df-ba60-a3ecd36da5d3.png)

