### PR TITLE
[优化] 步骤条的节点名称在较短时，右侧别截掉一点点的问题，解决了@6965

### DIFF
--- a/src/jigsaw/pc-components/steps/step.scss
+++ b/src/jigsaw/pc-components/steps/step.scss
@@ -32,7 +32,7 @@ $steps-prefix-cls: #{$jigsaw-prefix}-steps;
 
             .#{$steps-prefix-cls}-title {
                 max-width: calc(100% - 32px);
-                margin-right: 10px;
+                padding-right: 10px;
                 font-size: $font-size-lg;
                 white-space: nowrap;
                 overflow: hidden;


### PR DESCRIPTION
这个问题只在字数较少时才会出现：
![image](https://user-images.githubusercontent.com/42016535/128803027-4b86a12d-f4f4-42db-9f0f-4318e58c7607.png)
