### PR TITLE
[修复] 修复分页数据自动填充空白行过多问题；新增自动填充空白行开关；解决了@6913，@6891

### DIFF
--- a/src/app/demo/pc/table/auto-fill-up/demo.component.html
+++ b/src/app/demo/pc/table/auto-fill-up/demo.component.html
@@ -7,38 +7,41 @@
 <span>表格数据场景：</span>
 <jigsaw-select [(value)]="scenario" [data]="scenarioList"></jigsaw-select>
 
+<span>是否开启自动填充：</span>
+<jigsaw-switch [(checked)]="checked"></jigsaw-switch>
+
 <jigsaw-button *ngIf="scenario == 'common'" (click)="_$updateData()" colorType="primary">更新数据</jigsaw-button>
 <jigsaw-button *ngIf="scenario == 'common'" (click)="_$noData()" colorType="primary">无数据</jigsaw-button>
 <div *ngIf="scenario == 'common'" class="viewport">
     <div class="demo-cntr">
         <jigsaw-header class="demo-header">高度设置为百分比</jigsaw-header>
-        <jigsaw-table [data]="tableData" [columnDefines]="columnsCommonRender" height="100%"></jigsaw-table>
+        <jigsaw-table [data]="tableData" [columnDefines]="columnsCommonRender" height="100%" [autoFillUp]="checked"></jigsaw-table>
     </div>
     <div class="demo-cntr">
         <jigsaw-header class="demo-header">高度设置为固定值</jigsaw-header>
-        <jigsaw-table [data]="tableData" height="400px"></jigsaw-table>
+        <jigsaw-table [data]="tableData" height="400px" [autoFillUp]="checked"></jigsaw-table>
     </div>
     <div class="demo-cntr">
         <jigsaw-header class="demo-header">高度设置为计算值</jigsaw-header>
-        <jigsaw-table [data]="tableData" height="calc(100% - 100px)"></jigsaw-table>
+        <jigsaw-table [data]="tableData" height="calc(100% - 100px)" [autoFillUp]="checked"></jigsaw-table>
     </div>
     <div class="demo-cntr">
         <jigsaw-header class="demo-header">不设置高度</jigsaw-header>
-        <jigsaw-table [data]="tableData"></jigsaw-table>
+        <jigsaw-table [data]="tableData" [autoFillUp]="checked"></jigsaw-table>
     </div>
 </div>
 
 <div *ngIf="scenario == 'tree'" class="viewport">
     <div class="demo-cntr" style="width: 100%;">
         <jigsaw-header class="demo-header">高度设置为百分比</jigsaw-header>
-        <jigsaw-table [data]="treeTableData" [columnDefines]="columnsTree" height="100%"></jigsaw-table>
+        <jigsaw-table [data]="treeTableData" [columnDefines]="columnsTree" height="100%" [autoFillUp]="checked"></jigsaw-table>
     </div>
 </div>
 
 <div *ngIf="scenario == 'pageable'" class="viewport">
     <div class="demo-cntr" style="width:100%;">
-        <jigsaw-header class="demo-header">高度设置为固定值</jigsaw-header>
-        <jigsaw-table [data]="pageable" height="600px"></jigsaw-table>
+        <jigsaw-header class="demo-header">高度设置为固定值（分页数据只有在总页数仅有1页且已有数据还未填满表格高度时启用自动填充）</jigsaw-header>
+        <jigsaw-table [data]="pageable" height="600px" [autoFillUp]="checked"></jigsaw-table>
         <jigsaw-pagination style="margin-top: 8px" [data]="pageable" [pageSizeOptions]="[10, 20, 30, 50]" [searchable]="true"
             [showQuickJumper]="true" (search)="_$search($event)">
         </jigsaw-pagination>

--- a/src/app/demo/pc/table/auto-fill-up/demo.component.html
+++ b/src/app/demo/pc/table/auto-fill-up/demo.component.html
@@ -39,7 +39,7 @@
     <div class="demo-cntr" style="width:100%;">
         <jigsaw-header class="demo-header">高度设置为固定值</jigsaw-header>
         <jigsaw-table [data]="pageable" height="600px"></jigsaw-table>
-        <jigsaw-pagination style="margin-top: 8px" [data]="pageable" [pageSizeOptions]="[10, 20, 30]" [searchable]="true"
+        <jigsaw-pagination style="margin-top: 8px" [data]="pageable" [pageSizeOptions]="[10, 20, 30, 50]" [searchable]="true"
             [showQuickJumper]="true" (search)="_$search($event)">
         </jigsaw-pagination>
     </div>

--- a/src/app/demo/pc/table/auto-fill-up/demo.component.html
+++ b/src/app/demo/pc/table/auto-fill-up/demo.component.html
@@ -34,3 +34,13 @@
         <jigsaw-table [data]="treeTableData" [columnDefines]="columnsTree" height="100%"></jigsaw-table>
     </div>
 </div>
+
+<div *ngIf="scenario == 'pageable'" class="viewport">
+    <div class="demo-cntr" style="width:100%;">
+        <jigsaw-header class="demo-header">高度设置为固定值</jigsaw-header>
+        <jigsaw-table [data]="pageable" height="600px"></jigsaw-table>
+        <jigsaw-pagination style="margin-top: 8px" [data]="pageable" [pageSizeOptions]="[10, 20, 30]" [searchable]="true"
+            [showQuickJumper]="true" (search)="_$search($event)">
+        </jigsaw-pagination>
+    </div>
+</div>

--- a/src/app/demo/pc/table/auto-fill-up/demo.component.html
+++ b/src/app/demo/pc/table/auto-fill-up/demo.component.html
@@ -13,6 +13,7 @@
 <jigsaw-button *ngIf="scenario == 'common'" (click)="_$updateData()" colorType="primary">更新数据</jigsaw-button>
 <jigsaw-button *ngIf="scenario == 'common'" (click)="_$noData()" colorType="primary">无数据</jigsaw-button>
 <jigsaw-button *ngIf="scenario == 'pageable'" (click)="_$updateLessData()" colorType="primary">更新为短数据</jigsaw-button>
+<jigsaw-button *ngIf="scenario == 'pageable'" (click)="_$updateMoreData()" colorType="primary">更新为长数据</jigsaw-button>
 <div *ngIf="scenario == 'common'" class="viewport">
     <div class="demo-cntr">
         <jigsaw-header class="demo-header">高度设置为百分比</jigsaw-header>

--- a/src/app/demo/pc/table/auto-fill-up/demo.component.html
+++ b/src/app/demo/pc/table/auto-fill-up/demo.component.html
@@ -12,6 +12,7 @@
 
 <jigsaw-button *ngIf="scenario == 'common'" (click)="_$updateData()" colorType="primary">更新数据</jigsaw-button>
 <jigsaw-button *ngIf="scenario == 'common'" (click)="_$noData()" colorType="primary">无数据</jigsaw-button>
+<jigsaw-button *ngIf="scenario == 'pageable'" (click)="_$updateLessData()" colorType="primary">更新为短数据</jigsaw-button>
 <div *ngIf="scenario == 'common'" class="viewport">
     <div class="demo-cntr">
         <jigsaw-header class="demo-header">高度设置为百分比</jigsaw-header>

--- a/src/app/demo/pc/table/auto-fill-up/demo.component.ts
+++ b/src/app/demo/pc/table/auto-fill-up/demo.component.ts
@@ -194,6 +194,10 @@ export class TableAutoFillUpDemoComponent {
         this.pageable.fromAjax('mock-data/hr-list-short');
     }
 
+    _$updateMoreData() {
+        this.pageable.fromAjax('mock-data/hr-list');
+    }
+
     // ====================================================================
     // ignore the following lines, they are not important to this demo
     // ====================================================================

--- a/src/app/demo/pc/table/auto-fill-up/demo.component.ts
+++ b/src/app/demo/pc/table/auto-fill-up/demo.component.ts
@@ -7,6 +7,8 @@ import { HttpClient } from '@angular/common/http';
     styleUrls: ["./demo.component.css"]
 })
 export class TableAutoFillUpDemoComponent {
+    checked: boolean = true;
+
     scenario: "common" | "tree" | "pageable" = "common";
 
     scenarioList = new ArrayCollection([

--- a/src/app/demo/pc/table/auto-fill-up/demo.component.ts
+++ b/src/app/demo/pc/table/auto-fill-up/demo.component.ts
@@ -1,20 +1,23 @@
 import { Component } from "@angular/core";
-import { TableData, ColumnDefine, TableCellTextEditorRenderer, TableCellAutoCompleteEditorRenderer, TableCellNumericEditorRenderer, ArrayCollection, TreeTableData, TreeTableCellRenderer } from "jigsaw/public_api";
+import { TableData, ColumnDefine, TableCellTextEditorRenderer, TableCellAutoCompleteEditorRenderer, TableCellNumericEditorRenderer, ArrayCollection, TreeTableData, TreeTableCellRenderer, LocalPageableTableData } from "jigsaw/public_api";
+import { HttpClient } from '@angular/common/http';
 
 @Component({
     templateUrl: "./demo.component.html",
     styleUrls: ["./demo.component.css"]
 })
 export class TableAutoFillUpDemoComponent {
-    scenario: "common" | "tree" = "common";
+    scenario: "common" | "tree" | "pageable" = "common";
 
     scenarioList = new ArrayCollection([
         "common",
-        "tree"
+        "tree",
+        "pageable"
     ]);
 
     tableData: TableData;
     treeTableData: TreeTableData;
+    pageable: LocalPageableTableData;
 
     _$noData() {
         this.tableData.fromObject({
@@ -92,7 +95,7 @@ export class TableAutoFillUpDemoComponent {
         }
     ];
 
-    constructor() {
+    constructor(http: HttpClient) {
         this.tableData = new TableData(
             [
                 ["Tiger Nixon1", "System Architect", "8000"],
@@ -178,6 +181,11 @@ export class TableAutoFillUpDemoComponent {
                 { isParent: true, data: this.getRow(3) }
             ]
         });
+
+        this.pageable = new LocalPageableTableData();
+        this.pageable.http = http;
+        this.pageable.pagingInfo.pageSize = 10;
+        this.pageable.fromAjax('mock-data/hr-list');
     }
 
     // ====================================================================

--- a/src/app/demo/pc/table/auto-fill-up/demo.component.ts
+++ b/src/app/demo/pc/table/auto-fill-up/demo.component.ts
@@ -190,6 +190,10 @@ export class TableAutoFillUpDemoComponent {
         this.pageable.fromAjax('mock-data/hr-list');
     }
 
+    _$updateLessData() {
+        this.pageable.fromAjax('mock-data/hr-list-short');
+    }
+
     // ====================================================================
     // ignore the following lines, they are not important to this demo
     // ====================================================================

--- a/src/app/demo/pc/table/auto-fill-up/demo.module.ts
+++ b/src/app/demo/pc/table/auto-fill-up/demo.module.ts
@@ -1,12 +1,12 @@
 import {NgModule} from '@angular/core';
-import {JigsawButtonModule, JigsawHeaderModule, JigsawTableModule, JigsawSelectModule, JigsawPaginationModule} from "jigsaw/public_api";
+import {JigsawButtonModule, JigsawHeaderModule, JigsawTableModule, JigsawSelectModule, JigsawPaginationModule, JigsawSwitchModule} from "jigsaw/public_api";
 import {JigsawDemoDescriptionModule} from "app/demo-description/demo-description";
 import {TableAutoFillUpDemoComponent} from './demo.component';
 import { CommonModule } from '@angular/common';
 
 @NgModule({
     imports: [JigsawTableModule, JigsawDemoDescriptionModule, JigsawHeaderModule, JigsawButtonModule,
-        JigsawSelectModule, CommonModule, JigsawPaginationModule],
+        JigsawSelectModule, CommonModule, JigsawPaginationModule, JigsawSwitchModule],
     declarations: [TableAutoFillUpDemoComponent],
     exports: [TableAutoFillUpDemoComponent]
 })

--- a/src/app/demo/pc/table/auto-fill-up/demo.module.ts
+++ b/src/app/demo/pc/table/auto-fill-up/demo.module.ts
@@ -1,12 +1,12 @@
 import {NgModule} from '@angular/core';
-import {JigsawButtonModule, JigsawHeaderModule, JigsawTableModule, JigsawSelectModule} from "jigsaw/public_api";
+import {JigsawButtonModule, JigsawHeaderModule, JigsawTableModule, JigsawSelectModule, JigsawPaginationModule} from "jigsaw/public_api";
 import {JigsawDemoDescriptionModule} from "app/demo-description/demo-description";
 import {TableAutoFillUpDemoComponent} from './demo.component';
 import { CommonModule } from '@angular/common';
 
 @NgModule({
     imports: [JigsawTableModule, JigsawDemoDescriptionModule, JigsawHeaderModule, JigsawButtonModule,
-        JigsawSelectModule, CommonModule],
+        JigsawSelectModule, CommonModule, JigsawPaginationModule],
     declarations: [TableAutoFillUpDemoComponent],
     exports: [TableAutoFillUpDemoComponent]
 })

--- a/src/jigsaw/pc-components/table/table.html
+++ b/src/jigsaw/pc-components/table/table.html
@@ -80,7 +80,7 @@
                 <td *ngFor="let cell of this._$headerSettings;" attr.rowspan="1" style="display: table-cell;">
                     <ng-container>
                         <div class="jigsaw-table-cell-content">
-                            <span class="jigsaw-table-cell-text">--</span>
+                            <span class="jigsaw-table-cell-text"></span>
                         </div>
                     </ng-container>
                 </td>

--- a/src/jigsaw/pc-components/table/table.ts
+++ b/src/jigsaw/pc-components/table/table.ts
@@ -112,6 +112,10 @@ export class JigsawTable extends AbstractJigsawComponent implements OnInit, Afte
     public hideHeader: boolean = false;
 
     private _autoFillUp: boolean = false;
+
+    /**
+     * @NoMarkForCheckRequired
+     */
     @Input()
     public get autoFillUp(): boolean {
         return this._autoFillUp;

--- a/src/jigsaw/pc-components/table/table.ts
+++ b/src/jigsaw/pc-components/table/table.ts
@@ -37,7 +37,7 @@ import {
     TableHeadSetting
 } from "./table-typings";
 import {CallbackRemoval, CommonUtils} from "../../common/core/utils/common-utils";
-import {SortOrder} from "../../common/core/data/component-data";
+import {SortOrder, IPageable} from "../../common/core/data/component-data";
 import {
     DefaultCellRenderer,
     JigsawTableRendererModule,
@@ -312,11 +312,12 @@ export class JigsawTable extends AbstractJigsawComponent implements OnInit, Afte
     private _updateFillUpBlankRow(): void {
         this._$blankRow = [];
         this._changeDetectorRef.detectChanges();
-        if (this.data['pagingInfo'] !== undefined) {
-            if (this.data['pagingInfo'].totalPage !== 1) {
-                return;
-            }
+
+        const data: IPageable = <any>this.data;
+        if (data?.hasOwnProperty('pagingInfo') && data?.pagingInfo.totalPage > 1) {
+            return;
         }
+
         if (this.height === undefined || this._$cellSettings.length === 0) {
             return;
         }

--- a/src/jigsaw/pc-components/table/table.ts
+++ b/src/jigsaw/pc-components/table/table.ts
@@ -111,6 +111,17 @@ export class JigsawTable extends AbstractJigsawComponent implements OnInit, Afte
     @RequireMarkForCheck()
     public hideHeader: boolean = false;
 
+    private _autoFillUp: boolean = false;
+    @Input()
+    public get autoFillUp(): boolean {
+        return this._autoFillUp;
+    }
+
+    public set autoFillUp(value: boolean) {
+        this._autoFillUp = value;
+        this._updateFillUpBlankRow();
+    }
+
     private _selectedRow: number;
 
     /**
@@ -312,6 +323,10 @@ export class JigsawTable extends AbstractJigsawComponent implements OnInit, Afte
     private _updateFillUpBlankRow(): void {
         this._$blankRow = [];
         this._changeDetectorRef.detectChanges();
+
+        if (!this.autoFillUp) {
+            return;
+        }
 
         const data: IPageable = <any>this.data;
         if (data?.hasOwnProperty('pagingInfo') && data?.pagingInfo.totalPage > 1) {

--- a/src/jigsaw/pc-components/table/table.ts
+++ b/src/jigsaw/pc-components/table/table.ts
@@ -888,8 +888,6 @@ export class JigsawTable extends AbstractJigsawComponent implements OnInit, Afte
         this._renderer.setStyle(this._elementRef.nativeElement.querySelector('.jigsaw-table-body-range'),
             'max-height', this._maxHeight);
         this._tableHeaderElement = this._elementRef.nativeElement.querySelector(".jigsaw-table-header");
-
-        this._updateFillUpBlankRow();
     }
 
     ngOnDestroy() {

--- a/src/jigsaw/pc-components/table/table.ts
+++ b/src/jigsaw/pc-components/table/table.ts
@@ -123,6 +123,7 @@ export class JigsawTable extends AbstractJigsawComponent implements OnInit, Afte
 
     public set autoFillUp(value: boolean) {
         this._autoFillUp = value;
+        this._$blankRow = [];
         this._updateFillUpBlankRow();
     }
 
@@ -325,9 +326,6 @@ export class JigsawTable extends AbstractJigsawComponent implements OnInit, Afte
     public _$blankRow:string[] = [];
 
     private _updateFillUpBlankRow(): void {
-        this._$blankRow = [];
-        this._changeDetectorRef.detectChanges();
-
         if (!this.autoFillUp) {
             return;
         }

--- a/src/jigsaw/pc-components/table/table.ts
+++ b/src/jigsaw/pc-components/table/table.ts
@@ -312,6 +312,11 @@ export class JigsawTable extends AbstractJigsawComponent implements OnInit, Afte
     private _updateFillUpBlankRow(): void {
         this._$blankRow = [];
         this._changeDetectorRef.detectChanges();
+        if (this.data['pagingInfo'] !== undefined) {
+            if (this.data['pagingInfo'].totalPage !== 1) {
+                return;
+            }
+        }
         if (this.height === undefined || this._$cellSettings.length === 0) {
             return;
         }

--- a/src/jigsaw/pc-components/table/table.ts
+++ b/src/jigsaw/pc-components/table/table.ts
@@ -123,7 +123,6 @@ export class JigsawTable extends AbstractJigsawComponent implements OnInit, Afte
 
     public set autoFillUp(value: boolean) {
         this._autoFillUp = value;
-        this._$blankRow = [];
         this._updateFillUpBlankRow();
     }
 
@@ -326,6 +325,9 @@ export class JigsawTable extends AbstractJigsawComponent implements OnInit, Afte
     public _$blankRow:string[] = [];
 
     private _updateFillUpBlankRow(): void {
+        this._$blankRow = [];
+        this._changeDetectorRef.detectChanges();
+        
         if (!this.autoFillUp) {
             return;
         }
@@ -886,6 +888,8 @@ export class JigsawTable extends AbstractJigsawComponent implements OnInit, Afte
         this._renderer.setStyle(this._elementRef.nativeElement.querySelector('.jigsaw-table-body-range'),
             'max-height', this._maxHeight);
         this._tableHeaderElement = this._elementRef.nativeElement.querySelector(".jigsaw-table-header");
+
+        this._updateFillUpBlankRow();
     }
 
     ngOnDestroy() {

--- a/src/jigsaw/pc-components/table/table.ts
+++ b/src/jigsaw/pc-components/table/table.ts
@@ -328,7 +328,8 @@ export class JigsawTable extends AbstractJigsawComponent implements OnInit, Afte
             return;
         }
         const bodyBottom = bodyRangeEle.getBoundingClientRect().bottom;
-        const validBottom = lastRowEle.getBoundingClientRect().bottom;
+        const bodyScroll = bodyRangeEle.scrollTop;
+        const validBottom = lastRowEle.getBoundingClientRect().bottom + bodyScroll;
         const height = bodyBottom - validBottom - 1;
         const rowGap = Math.floor(height / 30);
         if (rowGap <= 0) {


### PR DESCRIPTION
- ‘--’单元格文字左右对齐方式不好添加配置，因为每列的需求可能不一样。可以在以后table的columDefine支持配置单元格文字左右后自动读取；

![image](https://user-images.githubusercontent.com/41236821/130937637-db70b98d-ba88-4bda-afea-a906aee297e5.png)
