### PR TITLE
[优化] 优化button-bar组件文字使用英文时底部会被切掉的问题，解决了@6900

### DIFF
--- a/src/app/demo/pc/button-bar/size/demo.component.html
+++ b/src/app/demo/pc/button-bar/size/demo.component.html
@@ -14,3 +14,14 @@
 
 <jigsaw-header level="3">直接设置height</jigsaw-header>
 <jigsaw-button-bar [(selectedItems)]="selectedTypes" [data]="cities" height="60"></jigsaw-button-bar>
+
+<jigsaw-header>英文字母也可以正常显示</jigsaw-header>
+
+<jigsaw-header level="3">small</jigsaw-header>
+<jigsaw-button-bar [(selectedItems)]="selectedTypesEn" [data]="citiesEn" preSize="small"></jigsaw-button-bar><br><br>
+
+<jigsaw-header level="3">default</jigsaw-header>
+<jigsaw-button-bar [(selectedItems)]="selectedTypesEn" [data]="citiesEn"></jigsaw-button-bar><br><br>
+
+<jigsaw-header level="3">直接设置height</jigsaw-header>
+<jigsaw-button-bar [(selectedItems)]="selectedTypesEn" [data]="citiesEn" height="60"></jigsaw-button-bar>

--- a/src/app/demo/pc/button-bar/size/demo.component.ts
+++ b/src/app/demo/pc/button-bar/size/demo.component.ts
@@ -14,7 +14,17 @@ export class ButtonBarSizeDemoComponent {
         {label: "西安", id: 6}
     ]);
     selectedTypes = {label: "上海-一个很长的地址", id: 2};
-
+    
+    citiesEn = new ArrayCollection([
+        {label: "BeiJing", id: 1},
+        {label: "ShangHaiiiiiiiiiiiiiiiiii", id: 2},
+        {label: "NanJing", id: 3},
+        {label: "ShenZhen", id: 4},
+        {label: "ChangSha", id: 5},
+        {label: "Xi'an", id: 6}
+    ]);
+    selectedTypesEn = {label: "NanJing", id: 3};
+    
     // ====================================================================
     // ignore the following lines, they are not important to this demo
     // ====================================================================

--- a/src/jigsaw/pc-components/list-and-tile/button-bar.scss
+++ b/src/jigsaw/pc-components/list-and-tile/button-bar.scss
@@ -49,6 +49,9 @@ $button-bar-prefix-cls: #{$jigsaw-prefix}-button-bar;
 
         & > p {
             max-width: 120px;
+            height: $height-sm;
+            line-height: $height-sm;
+            text-align: center;
             text-overflow: ellipsis;
             white-space: nowrap;
             overflow: hidden;


### PR DESCRIPTION
Change-Id: I02e47f0cd1811f0491b3970837ff61e116a22489

![image](https://user-images.githubusercontent.com/41236821/131280763-8622d3ed-97ac-4a8c-8439-418f6a15516c.png)
