### PR TITLE
[故障]表单中的级联组件配置dataGenerator无效的问题

### DIFF
--- a/src/jigsaw/pc-components/cascade/cascade.ts
+++ b/src/jigsaw/pc-components/cascade/cascade.ts
@@ -118,6 +118,7 @@ export class JigsawCascade extends AbstractJigsawComponent implements AfterViewI
      * $demo = cascade/lazy-load
      * $demo = cascade/selected-items
      */
+    @RequireMarkForCheck()
     @Input()
     public get dataGenerator(): CascadeDateGenerator {
         return this._dataGenerator;
@@ -125,7 +126,6 @@ export class JigsawCascade extends AbstractJigsawComponent implements AfterViewI
 
     public set dataGenerator(value: CascadeDateGenerator) {
         this._dataGenerator = value ? value : this._treeDataGenerator;
-        this._changeDetectorRef.markForCheck();
     }
 
     /**

--- a/src/jigsaw/pc-components/cascade/cascade.ts
+++ b/src/jigsaw/pc-components/cascade/cascade.ts
@@ -110,15 +110,23 @@ export class JigsawCascade extends AbstractJigsawComponent implements AfterViewI
      */
     public _cascadeDataList: CascadeData[] = [];
 
+    private _dataGenerator: CascadeDateGenerator;
+
     /**
      * 生成级联数据的函数，一般用于需要异步加载的数据的生产
      *
      * $demo = cascade/lazy-load
      * $demo = cascade/selected-items
      */
-    @RequireMarkForCheck()
     @Input()
-    public dataGenerator: CascadeDateGenerator;
+    public get dataGenerator(): CascadeDateGenerator {
+        return this._dataGenerator;
+    }
+
+    public set dataGenerator(value: CascadeDateGenerator) {
+        this._dataGenerator = value ? value : this._treeDataGenerator;
+        this._changeDetectorRef.markForCheck();
+    }
 
     /**
      * 一般配合`dataGenerator`使用，用于指明`dataGenerator`函数执行的上下文对象，

--- a/src/jigsaw/pc-components/cascade/cascade.ts
+++ b/src/jigsaw/pc-components/cascade/cascade.ts
@@ -110,8 +110,6 @@ export class JigsawCascade extends AbstractJigsawComponent implements AfterViewI
      */
     public _cascadeDataList: CascadeData[] = [];
 
-    private _dataGenerator: CascadeDateGenerator;
-
     /**
      * 生成级联数据的函数，一般用于需要异步加载的数据的生产
      *
@@ -120,13 +118,7 @@ export class JigsawCascade extends AbstractJigsawComponent implements AfterViewI
      */
     @RequireMarkForCheck()
     @Input()
-    public get dataGenerator(): CascadeDateGenerator {
-        return this._dataGenerator;
-    }
-
-    public set dataGenerator(value: CascadeDateGenerator) {
-        this._dataGenerator = value ? value : this._treeDataGenerator;
-    }
+    public dataGenerator: CascadeDateGenerator;
 
     /**
      * 一般配合`dataGenerator`使用，用于指明`dataGenerator`函数执行的上下文对象，

--- a/src/ngx-formly/jigsaw/cascade/src/cascade.type.ts
+++ b/src/ngx-formly/jigsaw/cascade/src/cascade.type.ts
@@ -35,9 +35,9 @@ import {ArrayCollection, JigsawCascade, JigsawComboSelect} from "@rdkmaster/jigs
                 <jigsaw-cascade
                     [width]="to.width"
                     [height]="to.height"
-                    [dataGenerator]="to.dataGenerator"
-                    [generatorContext]="to.generatorContext"
                     [data]="to.data"
+                    [generatorContext]="to.generatorContext"
+                    [dataGenerator]="to.dataGenerator"
                     [(selectedItems)]="to.selectedItems"
                     [multipleSelect]="to.multipleSelect"
                     [labelField]="to.labelField"

--- a/src/ngx-formly/jigsaw/cascade/src/cascade.type.ts
+++ b/src/ngx-formly/jigsaw/cascade/src/cascade.type.ts
@@ -6,36 +6,21 @@ import {ArrayCollection, JigsawCascade, JigsawComboSelect} from "@rdkmaster/jigs
     selector: 'formly-field-jigsaw-cascade',
     template: `
         <jigsaw-combo-select
+            *ngIf="!!to.dataGenerator; else dataTmp"
             [formControl]="formControl"
             [formlyAttributes]="field"
             [width]="to.width"
-            [height]="to.height"
             [(value)]="_$comboValue"
             [labelField]="to.labelField"
             [placeholder]="to.placeholder"
             [openTrigger]="to.openTrigger"
             [closeTrigger]="to.closeTrigger"
-            [maxWidth]="to.maxWidth"
-            [(open)]="to.open"
-            [showBorder]="to.showBorder"
-            [autoClose]="to.autoClose"
-            [autoWidth]="to.autoWidth"
-            [clearable]="to.clearable"
-            [searchable]="to.searchable"
-            [searching]="to.searching"
-            [searchKeyword]="to.searchKeyword"
-            [searchBoxMinWidth]="to.searchBoxMinWidth"
             [valid]="to.valid && !showError"
-            (valueChange)="to.valueChange && to.valueChange($event)"
-            (select)="to.select && to.select($event)"
-            (openChange)="to.openChange && to.openChange($event)"
-            (searchKeywordChange)="to.searchKeywordChange && to.searchKeywordChange($event)"
-            (remove)="to.remove && to.remove($event)">
+            [autoWidth]="to.autoWidth">
             <ng-template>
                 <jigsaw-cascade
                     [width]="to.width"
                     [height]="to.height"
-                    [data]="to.data"
                     [generatorContext]="to.generatorContext"
                     [dataGenerator]="to.dataGenerator"
                     [(selectedItems)]="to.selectedItems"
@@ -43,12 +28,38 @@ import {ArrayCollection, JigsawCascade, JigsawComboSelect} from "@rdkmaster/jigs
                     [labelField]="to.labelField"
                     [trackItemBy]="to.trackItemBy"
                     [searchable]="to.searchable"
-                    [pageSize]="to.pageSize"
                     [optionWidth]="to.optionWidth"
                     (selectedItemsChange)="_$selectItemsChange($event)">
                 </jigsaw-cascade>
             </ng-template>
         </jigsaw-combo-select>
+        <ng-template #dataTmp>
+            <jigsaw-combo-select
+                [formControl]="formControl"
+                [formlyAttributes]="field"
+                [width]="to.width"
+                [(value)]="_$comboValue"
+                [labelField]="to.labelField"
+                [placeholder]="to.placeholder"
+                [openTrigger]="to.openTrigger"
+                [closeTrigger]="to.closeTrigger"
+                [valid]="to.valid && !showError"
+                [autoWidth]="to.autoWidth">
+                <ng-template>
+                    <jigsaw-cascade
+                        [width]="to.width"
+                        [data]="to.data"
+                        [(selectedItems)]="to.selectedItems"
+                        [multipleSelect]="to.multipleSelect"
+                        [labelField]="to.labelField"
+                        [trackItemBy]="to.trackItemBy"
+                        [searchable]="to.searchable"
+                        [optionWidth]="to.optionWidth"
+                        (selectedItemsChange)="_$selectItemsChange($event)">
+                    </jigsaw-cascade>
+                </ng-template>
+            </jigsaw-combo-select>
+        </ng-template>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
原来的data属性是配置在后面的，导致配置dataGenerator被data属性的setter方法中的逻辑给覆盖了。所以要将data的配置挪到前面：

![image](https://user-images.githubusercontent.com/42016535/131306291-87fcc472-f7dd-4edc-8f74-8b999cbd1eb8.png)

![image](https://user-images.githubusercontent.com/42016535/131306538-33ad054f-6a8e-453c-828b-6b750580d84e.png)
