### PR TITLE
[优化] 浅色下弹出notification，然后切换为深色，组件背景可以随之改变，解决了@6978

### DIFF
--- a/src/jigsaw/common/core/theming/prebuilt/settings/paletx-pro-dark.scss
+++ b/src/jigsaw/common/core/theming/prebuilt/settings/paletx-pro-dark.scss
@@ -247,6 +247,7 @@ $brand-active-dark: $blue-8;
 /*@public*/ $bg-disabled: $gray-6;
 /*@public*/ $bg-hover: $gray-4;
 /*@public*/ $bg-active: $gray-5;
+$bg-popup: $gray-2;
 $bg-component: transparent;
 $bg-header: $gray-4;
 $bg-gray: $gray-3;

--- a/src/jigsaw/common/core/theming/prebuilt/settings/paletx-pro-light.scss
+++ b/src/jigsaw/common/core/theming/prebuilt/settings/paletx-pro-light.scss
@@ -247,6 +247,7 @@ $brand-active-dark: $blue-8-dark;
 /*@public*/ $bg-disabled: $gray-3;
 /*@public*/ $bg-hover: $blue-1;
 /*@public*/ $bg-active: $blue-2;
+$bg-popup: $gray-1;
 $bg-component: transparent;
 $bg-header: $gray-3;
 $bg-gray: $gray-3;

--- a/src/jigsaw/common/core/theming/prebuilt/settings/vmax-pro-light.scss
+++ b/src/jigsaw/common/core/theming/prebuilt/settings/vmax-pro-light.scss
@@ -247,6 +247,7 @@ $brand-active-dark: $blue-8-dark;
 /*@public*/ $bg-disabled: $gray-3;
 /*@public*/ $bg-hover: $blue-1;
 /*@public*/ $bg-active: $blue-2;
+$bg-popup: $gray-1;
 $bg-component: transparent;
 $bg-header: $gray-3;
 $bg-gray: $gray-3;

--- a/src/jigsaw/pc-components/notification/notification.scss
+++ b/src/jigsaw/pc-components/notification/notification.scss
@@ -6,7 +6,7 @@
 
 .jigsaw-notification {
     border-radius: $border-radius-base;
-    background: $bg-component;
+    background: $bg-popup;
     box-shadow: $box-shadow-lv3;
     padding: 18px 22px 18px 18px;
     height: 100%;


### PR DESCRIPTION
Change-Id: I85b327e6e4c59ffecaea710000104e651ed9ea36

本质上notification组件背景色透明，使用的是popup的背景色，且不存在透明背景的场景，故修改notification的背景色，以保两种皮肤切换时背景色可变。

![image](https://user-images.githubusercontent.com/41236821/131345345-3df7d9b3-82b3-448d-a0e6-b655ec669224.png)
