### PR TITLE
[优化] collapse折叠组标题栏悬浮背景变蓝；折叠下拉组件折叠组标题悬浮背景变蓝，文字变蓝；解决了@6876

### DIFF
--- a/src/jigsaw/pc-components/collapse/collapse.scss
+++ b/src/jigsaw/pc-components/collapse/collapse.scss
@@ -19,6 +19,10 @@ $collapse-prefix: #{$jigsaw-prefix}-collapse;
             font-weight: bold;
             cursor: pointer;
 
+            &:hover{
+                background: $brand-lighten;
+            }
+
             > div {
                 display: flex;
                 align-items: center;

--- a/src/jigsaw/pc-components/select/select.scss
+++ b/src/jigsaw/pc-components/select/select.scss
@@ -222,6 +222,16 @@ $jigsaw-list-option: #{$jigsaw-prefix}-list-option;
                     .#{$jigsaw-collapse}-header {
                         padding-left: 8px;
 
+                        &:hover {
+                            .#{$select-prefix-cls}-option-title {
+                                color: $brand-default;
+                            }
+
+                            .#{$jigsaw-collapse}-arrow {
+                                color: $brand-default;
+                            }
+                        }
+
                         .#{$select-prefix-cls}-option-title {
                             font-size: $font-title-med;
                             color: $font-color-heading;


### PR DESCRIPTION
Change-Id: I5318915760dafa4b3773ba14326a1ad548e8cad0

![image](https://user-images.githubusercontent.com/41236821/132278001-31ec439a-9b18-4fa9-9aac-e69e6a17d34b.png)

![image](https://user-images.githubusercontent.com/41236821/132278018-e09e6c86-ba1f-41ba-a4dc-43dc73cad81d.png)

