### PR TITLE
[优化] Switch组件对齐规范，对齐各size组件高度，解决了@6886

### DIFF
--- a/src/jigsaw/pc-components/switch/switch.scss
+++ b/src/jigsaw/pc-components/switch/switch.scss
@@ -10,7 +10,7 @@ $switch-prefix: #{$jigsaw-prefix}-switch;
 }
 
 .#{$switch-prefix} {
-    --switch-height: 24px;
+    --switch-height: 20px;
     @include inline-block;
     position: relative;
     height: var(--switch-height);


### PR DESCRIPTION
Change-Id: I2e716cd639afe2fcd328293a705d84d4ae25e2d9
![image](https://user-images.githubusercontent.com/41236821/132312628-38f19f69-7842-4847-a11c-68387031ba57.png)
