### PR TITLE
[修复] 修复了button组件在弹框中宽度不对的问题，解决了@6815

### DIFF
--- a/src/jigsaw/pc-components/button/button.ts
+++ b/src/jigsaw/pc-components/button/button.ts
@@ -111,10 +111,13 @@ export class JigsawButton extends AbstractJigsawComponent implements AfterViewIn
     }
 
     ngAfterViewInit() {
-        if (!this.text.nativeElement.innerText) {
-            console.log(this.element)
-            this._renderer.addClass(this.element.nativeElement, 'jigsaw-button-icon');
-        }
+        this.runAfterMicrotasks(() => {
+            this._zone.run(() => {
+                if (!this.text.nativeElement.innerText) {
+                    this._renderer.addClass(this.element.nativeElement, 'jigsaw-button-icon');
+                }
+            });
+        });
     }
 }
 


### PR DESCRIPTION
Change-Id: Ia58b5e2b37b73d02879c24289113d89cd4b59abc

![image](https://user-images.githubusercontent.com/41236821/133561713-4cd72eed-7906-4a8b-97f8-fdbf0995dcdd.png)
