### PR TITLE
[优化] 英文状态下，表格的分页按钮中的单词Page显示完全，解决了@6768

### DIFF
--- a/src/jigsaw/pc-components/pagination/pagination.scss
+++ b/src/jigsaw/pc-components/pagination/pagination.scss
@@ -104,6 +104,8 @@ $jigsaw-input: #{$jigsaw-prefix}-input;
                 .#{$jigsaw-prefix}-combo-select-selection {
                     height: 100%;
                     min-height: unset;
+                    padding: 0 8px;
+
                     .#{$jigsaw-prefix}-combo-select-selection-rendered {
                         display: flex;
                         align-items: center;


### PR DESCRIPTION
Change-Id: Ia0549c6196ec724fd14e582915c71cabd46a9a62

![image](https://user-images.githubusercontent.com/41236821/135376933-73d8475d-9b95-4762-9230-2bd0b0dc2ad8.png)
