### PR TITLE
[优化] 树表的树节点列改为左对齐，解决了@6836

### DIFF
--- a/src/jigsaw/pc-components/table/table-renderer.ts
+++ b/src/jigsaw/pc-components/table/table-renderer.ts
@@ -638,13 +638,22 @@ export type TreeTableCellData = { id: string, open: boolean, isParent: boolean, 
             </span>
             <span>{{cellData.data}}</span>
         </div>
-    `
+    `,
+    styles: [
+        `
+        .jigsaw-table-tree-cell {
+            justify-content: flex-start;
+            margin-left: 8px;
+        }
+        `
+    ],
 })
 export class TreeTableCellRenderer extends TableCellRendererBase {
     public cellData: TreeTableCellData;
     public tableData: PageableTreeTableData;
 
     public get indent(): string {
+        console.log((this.cellData.id.length - 1) * 20 + 'px')
         return (this.cellData.id.length - 1) * 20 + 'px';
     }
 

--- a/src/jigsaw/pc-components/table/table-renderer.ts
+++ b/src/jigsaw/pc-components/table/table-renderer.ts
@@ -653,7 +653,6 @@ export class TreeTableCellRenderer extends TableCellRendererBase {
     public tableData: PageableTreeTableData;
 
     public get indent(): string {
-        console.log((this.cellData.id.length - 1) * 20 + 'px')
         return (this.cellData.id.length - 1) * 20 + 'px';
     }
 


### PR DESCRIPTION
Change-Id: Ibdbf1ef306f5d91d56c5db8e5b7786087d5e7ece

![image](https://user-images.githubusercontent.com/41236821/135378685-f6bf81c7-531c-494e-a9f2-267f65cdf2d0.png)
