### PR TITLE
[修复] 修复tab-bar下拉菜单disabled选项，鼠标hover时背景颜色正常显示，解决了@6759

### DIFF
--- a/src/jigsaw/pc-components/list-and-tile/list-option.scss
+++ b/src/jigsaw/pc-components/list-and-tile/list-option.scss
@@ -33,7 +33,7 @@ $list-option-prefix-cls: #{$jigsaw-prefix}-list-option;
         cursor: not-allowed;
 
         &:hover {
-            background: none;
+            background: $bg-body;
         }
 
         .#{$list-option-prefix-cls}-title,


### PR DESCRIPTION
Change-Id: I51d9e5e8c990d17cff343e3d5fa1e8514ad24989

![image](https://user-images.githubusercontent.com/41236821/137089996-a7a3d182-3d07-407d-ae34-519fe607aee8.png)
