### PR TITLE
[优化] Vmax的导航菜单一级菜单选中文本调整为白色，关联@6671

### DIFF
--- a/src/jigsaw/pc-components/menu/navigation-menu.scss
+++ b/src/jigsaw/pc-components/menu/navigation-menu.scss
@@ -622,6 +622,7 @@ $nav-menu-prefix-cls: #{$jigsaw-prefix}-nav-menu;
 
                 .#{$nav-menu-prefix-cls}-item-selected-top {
                     background-color: #212a33;
+                    color: $font-color-default-dark;
                 }
             }
 


### PR DESCRIPTION
Change-Id: I94ec50d2369111adbcba4e1b3d784aca5a007ec7

![image](https://user-images.githubusercontent.com/41236821/143021430-334a6b06-0c11-4e06-8bd2-f976843a80d4.png)
