### PR TITLE
[优化] checkbox的框和文本间距留白改为8px，解决了@6694

### DIFF
--- a/src/jigsaw/pc-components/checkbox/checkbox.scss
+++ b/src/jigsaw/pc-components/checkbox/checkbox.scss
@@ -3,7 +3,8 @@
 $checkbox-prefix-cls: #{$jigsaw-prefix}-checkbox;
 
 .#{$checkbox-prefix-cls}-host {
-    @include inline-block;
+    display: inline-flex;
+
     &.#{$checkbox-prefix-cls}-error .#{$checkbox-prefix-cls}-wrapper {
         &:hover {
             > .#{$checkbox-prefix-cls} {
@@ -20,8 +21,8 @@ $checkbox-prefix-cls: #{$jigsaw-prefix}-checkbox;
     position: relative;
     left: 0;
     margin: 0;
-    display: inline-block;
-    vertical-align: text-bottom;
+    display: inline-flex;
+    align-items: center;
     outline: none;
     font-size: $font-size-text-base;
     line-height: 1;


### PR DESCRIPTION
Change-Id: I9b68963ebe7a0ef22b4e15456822514cc476c7c9

![image](https://user-images.githubusercontent.com/41236821/143390199-fc2fd404-5d2f-40e9-b2f7-48765be569ce.png)
