### PR TITLE
[优化] Breadcrumb组件当前页文字取消悬浮下划线，解决了@6726

### DIFF
--- a/src/jigsaw/pc-components/breadcrumb/breadcrumb.scss
+++ b/src/jigsaw/pc-components/breadcrumb/breadcrumb.scss
@@ -59,7 +59,7 @@ $bc-prefix-cls: #{$jigsaw-prefix}-breadcrumb;
             height: $height-sm;
             color: $brand-default-light;
             font-size: $font-size-lg;
-            &:hover{
+            &:hover {
                 color: $brand-hover-light;
             }
             &.#{$bc-prefix-cls}-current {
@@ -114,6 +114,7 @@ $bc-prefix-cls: #{$jigsaw-prefix}-breadcrumb;
                 }
                 .#{$bc-prefix-cls}-label {
                     color: $font-color-heading-bold;
+                    text-decoration: none;
                 }
             }
         }


### PR DESCRIPTION
Change-Id: I3e8be68594c3cfb641dc5dd040847d645d64a55f
![image](https://user-images.githubusercontent.com/41236821/146718793-6a70eae0-4e86-42f1-99f7-5619399e2fbc.png)
