### PR TITLE
[优化] Jigsaw-tree修改节点、删除节点图标更新；图标大小对齐规范；解决了@6723

### DIFF
--- a/src/jigsaw/pc-components/tree/tree-ext.ts
+++ b/src/jigsaw/pc-components/tree/tree-ext.ts
@@ -91,8 +91,8 @@ export class JigsawTreeExt extends AbstractJigsawComponent implements AfterViewI
     public size: "default" | "medium" | "large" = "default";
 
     private _iconSuit: ZTreeIconSuit = {
-        edit: "ea0c",
-        remove: "e9c3",
+        edit: "e166",
+        remove: "e179",
         open: "e4e4",
         close: "e4e3",
         document: "e9d5",

--- a/src/jigsaw/pc-components/tree/tree.scss
+++ b/src/jigsaw/pc-components/tree/tree.scss
@@ -31,7 +31,10 @@ $jigsaw-tree: #{$jigsaw-prefix}-tree;
         &[class*="ico_close"],
         &[class*="ico_docu"] {
             position: relative;
+            width: 16px;
+            height: 16px;
             background-image: none;
+
             &::after {
                 position: absolute;
                 display: flex;
@@ -40,7 +43,7 @@ $jigsaw-tree: #{$jigsaw-prefix}-tree;
                 width: 100%;
                 height: 100%;
                 font-family: "iconfont" !important;
-                font-size: $font-size-lg;
+                font-size: $font-title-lg;
                 color: $icon-color-default;
                 cursor: pointer;
                 overflow: hidden;


### PR DESCRIPTION
Change-Id: Iaea5efcf70746e539ec0e7f3cb9685078e5cf7e3

![image](https://user-images.githubusercontent.com/41236821/146733424-7661522e-ca54-4d1c-9088-718baf487c59.png)
