### PR TITLE
[优化] Jigsaw-switch组件圆点阴影更显眼，解决了@6722

### DIFF
--- a/src/jigsaw/pc-components/switch/switch.scss
+++ b/src/jigsaw/pc-components/switch/switch.scss
@@ -41,7 +41,7 @@ $switch-prefix: #{$jigsaw-prefix}-switch;
         top: 1px;
         border-radius: 50%;
         background-color: $bg-body-light;
-        box-shadow: $box-shadow-lv1;
+        box-shadow: 1px 1px 3px hsla(0, 0%, 0%, 0.2);
         content: " ";
         cursor: pointer;
         transition: all $animation-duration-slow, width $animation-duration-slow;
@@ -52,7 +52,6 @@ $switch-prefix: #{$jigsaw-prefix}-switch;
     }
 
     &:focus {
-        box-shadow: 0 0 0 2px $brand-active-lighten;
         outline: 0;
     }
 


### PR DESCRIPTION
Change-Id: I96744e07f942500a310ee541df62e2a1b387d343

![image](https://user-images.githubusercontent.com/41236821/146739953-615ce465-0593-49d6-ac64-bc0683e2de52.png)
