### PR TITLE
[优化]  tree组件操作按钮离文字16px距离，关联@6575

### DIFF
--- a/src/jigsaw/pc-components/tree/tree.scss
+++ b/src/jigsaw/pc-components/tree/tree.scss
@@ -68,6 +68,10 @@ $jigsaw-tree: #{$jigsaw-prefix}-tree;
     }
 }
 
+.ztree li span.node_name {
+    margin-right: 16px;
+}
+
 .ztree li {
     span {
         &.button.switch {


### PR DESCRIPTION
Change-Id: Ib96f29adae4374da1cc712b157a22f9e14332d0c

![image](https://user-images.githubusercontent.com/41236821/149899874-8f02320d-118b-4949-b001-ac1a4377ffcc.png)
