### PR TITLE
[优化] Breadcrumb组件高度对齐到规范的48px，关联@6602

### DIFF
--- a/src/jigsaw/pc-components/breadcrumb/breadcrumb.scss
+++ b/src/jigsaw/pc-components/breadcrumb/breadcrumb.scss
@@ -3,7 +3,7 @@ $jigsaw-breadcrumb: #{$jigsaw-prefix}-breadcrumb;
 .#{$jigsaw-breadcrumb}-host {
     display: flex;
     align-items: center;
-    height: 54px;
+    height: 48px;
     padding: 0 12px;
     background: $bg-container;
     font-size: $font-title-med;
@@ -66,7 +66,6 @@ $jigsaw-breadcrumb: #{$jigsaw-prefix}-breadcrumb;
     }
 
     &.#{$jigsaw-breadcrumb}-inner {
-        height: $height-base;
         padding: 0 8px;
         font-size: $font-size-base;
         background: $bg-body;


### PR DESCRIPTION
Change-Id: I6cc16f8b1d4057294f69cab896db75b8d9cf1050

![image](https://user-images.githubusercontent.com/41236821/150079760-1ab15ec9-90fe-41e4-b12e-a4abbab1e2f7.png)
