### PR TITLE
[故障] 修复穿梭框使用普通数组作为data时无法显示数据，关联@6433

### DIFF
--- a/src/jigsaw/pc-components/transfer/transfer.ts
+++ b/src/jigsaw/pc-components/transfer/transfer.ts
@@ -340,7 +340,8 @@ export class JigsawTransfer extends AbstractJigsawComponent implements OnDestroy
                         this.sourceComponent.reset();
                     })
                     this._refreshForPageableArray(value);
-                } else if (value instanceof ArrayCollection) {
+                } else if (value instanceof ArrayCollection || value instanceof Array) {
+                    value = value instanceof Array ? new ArrayCollection(value) : value;
                     this._refreshForArray(value);
                 } else {
                     console.error("输入的数据结构与渲染器不匹配")


### PR DESCRIPTION
Change-Id: I8973196dd98c058f795c0358cbaace8e0dc4c334