### PR TITLE
[优化] navigation组件展开按钮和规范对齐，解决了@6406

### DIFF
--- a/src/jigsaw/pc-components/menu/navigation-menu.html
+++ b/src/jigsaw/pc-components/menu/navigation-menu.html
@@ -11,7 +11,7 @@
                 <i *ngIf="!collapsed" [ngClass]="menuItem.icon || 'iconfont iconfont-e231'"></i>
                 <span>{{menuItem.label}}</span>
                 <i *ngIf="menuItem?.nodes?.length > 0 && !collapsed"
-                    class="iconfont iconfont-e24c jigsaw-nav-menu-item-arrow"></i>
+                    class="iconfont iconfont-e24f jigsaw-nav-menu-item-arrow"></i>
             </div>
             <div class="jigsaw-nav-menu-submenus" [ngClass]="{'jigsaw-nav-menu-submenus-actived': menuItem.isActive}"
                 [@collapseMotion]="menuItem.isActive ? 'expanded' : 'collapsed' ">


### PR DESCRIPTION
<img width="324" alt="image" src="https://user-images.githubusercontent.com/41236821/159651590-2036cf3d-ac5f-4dff-bffd-e62bb96f4b9b.png">
