### PR TITLE
[优化] 解决了pagination组件折叠状态在宽度不足时会换行的问题，解决了@6402

### DIFF
--- a/src/jigsaw/pc-components/pagination/pagination-item.scss
+++ b/src/jigsaw/pc-components/pagination/pagination-item.scss
@@ -1,7 +1,7 @@
 $jigsaw-page: #{$jigsaw-prefix}-page;
 
 .#{$jigsaw-page}-item-host {
-    @include inline-block();
+    display: inline-flex;
     margin-right: 8px;
     vertical-align: top;
 


### PR DESCRIPTION
<img width="532" alt="image" src="https://user-images.githubusercontent.com/41236821/159653744-47617666-8932-4ebe-a73b-da49856b020f.png">
