### PR TITLE
[优化] 树表开闭的图标颜色修改为 #737373，关联了@6420

### DIFF
--- a/src/jigsaw/pc-components/table/table.scss
+++ b/src/jigsaw/pc-components/table/table.scss
@@ -151,7 +151,7 @@ $jigsaw-table: #{$jigsaw-prefix}-table;
             align-items: center;
             margin-right: 2px;
             font-size: $icon-size-sm;
-            color: $primary-default;
+            color: $icon-color-stress;
             cursor: pointer;
         }
     }


### PR DESCRIPTION
Change-Id: Ibf90cad543d536a45f183f3430efe271ca486cf4

![image](https://user-images.githubusercontent.com/41236821/160990084-f36922db-d9da-4aa1-8536-37ac16797cd0.png)
