### PR TITLE
[优化] Navigation组件对齐规范，包括图标大小、图标和文本间距、选中状态文本颜色；关联了@6304

### DIFF
--- a/src/app/demo/pc/menu/navigation/demo.component.ts
+++ b/src/app/demo/pc/menu/navigation/demo.component.ts
@@ -1,5 +1,5 @@
-import {Component} from "@angular/core";
-import {SimpleTreeData} from "jigsaw/public_api";
+import { Component } from "@angular/core";
+import { SimpleTreeData } from "jigsaw/public_api";
 
 @Component({
     templateUrl: './demo.component.html',
@@ -38,10 +38,16 @@ export class NavigationMenuNavDemo {
         `);
         const xmlData = `
             <node>
-                <node label="当前告警" icon="iconfont iconfont-e5fd" selected="true"></node>
-                <node label="历史告警" icon="iconfont iconfont-e5f7"></node>
-                <node label="通知" icon="iconfont iconfont-e605"></node>
-                <node label="告警设置" icon="iconfont iconfont-e36f"></node>
+                <node label="标准图标1" icon="iconfont iconfont-e231" selected="true"></node>
+                <node label="标准图标2" icon="iconfont iconfont-e261"></node>
+                <node label="标准图标3" icon="iconfont iconfont-e2f6"></node>
+                <node label="标准图标4" icon="iconfont iconfont-e2d4"></node>
+                <node label="标准图标5" icon="iconfont iconfont-e17c"></node>
+                <node label="标准图标6" icon="iconfont iconfont-e0d1"></node>
+                <node label="标准图标7" icon="iconfont iconfont-e191"></node>
+                <node label="标准图标8" icon="iconfont iconfont-e54a"></node>
+                <node label="标准图标9" icon="iconfont iconfont-e212"></node>
+                <node label="标准图标10" icon="iconfont iconfont-e367"></node>
             </node>
         `;
         this.data2.fromXML(xmlData);

--- a/src/app/demo/pc/menu/navigation/demo.component.ts
+++ b/src/app/demo/pc/menu/navigation/demo.component.ts
@@ -1,5 +1,5 @@
-import { Component } from "@angular/core";
-import { SimpleTreeData } from "jigsaw/public_api";
+import {Component} from "@angular/core";
+import {SimpleTreeData} from "jigsaw/public_api";
 
 @Component({
     templateUrl: './demo.component.html',

--- a/src/jigsaw/pc-components/menu/navigation-menu.scss
+++ b/src/jigsaw/pc-components/menu/navigation-menu.scss
@@ -34,7 +34,7 @@ $jigsaw-nav-menu: #{$jigsaw-prefix}-nav-menu;
                     align-items: center;
                     width: 40px;
                     height: 100%;
-                    margin-right: 10px;
+                    font-size: 18px;
                     text-align: center;
                 }
 
@@ -71,6 +71,7 @@ $jigsaw-nav-menu: #{$jigsaw-prefix}-nav-menu;
                         width: 14px;
                         height: 100%;
                         margin-right: 10px;
+                        font-size: 18px;
                         text-align: center;
                     }
 
@@ -80,7 +81,6 @@ $jigsaw-nav-menu: #{$jigsaw-prefix}-nav-menu;
 
                     &.#{$jigsaw-nav-menu}-sub-item-selected {
                         background-color: $nav-active;
-                        color: $nav-color-active;
                     }
 
                     &.#{$jigsaw-nav-menu}-sub-item-collapsed {
@@ -101,7 +101,6 @@ $jigsaw-nav-menu: #{$jigsaw-prefix}-nav-menu;
 
             .#{$jigsaw-nav-menu}-item-selected-top {
                 background-color: $nav-active;
-                color: $brand-default;
             }
         }
 
@@ -153,10 +152,6 @@ $jigsaw-nav-menu: #{$jigsaw-prefix}-nav-menu;
                     background: $bg-hover;
                 }
 
-                &.#{$jigsaw-nav-menu}-item-selected-top {
-                    color: $brand-default;
-                }
-
                 .#{$jigsaw-nav-menu}-item-arrow {
                     position: absolute;
                     right: 16px;
@@ -183,16 +178,11 @@ $jigsaw-nav-menu: #{$jigsaw-prefix}-nav-menu;
                 }
             }
 
-            .#{$jigsaw-nav-menu}-item-selected {
-                color: $brand-default;
-            }
-
             .#{$jigsaw-nav-menu}-item-selected-top {
                 background: $bg-body;
             }
 
             .#{$jigsaw-nav-menu}-sub-item-selected {
-                color: $brand-default;
                 background: $bg-body;
             }
         }
@@ -285,7 +275,6 @@ $jigsaw-nav-menu: #{$jigsaw-prefix}-nav-menu;
 
                         &.#{$jigsaw-nav-menu}-sub-item-selected {
                             background-color: #212a33;
-                            color: $font-color-white;
                         }
                     }
                 }

--- a/src/jigsaw/pc-components/menu/navigation-menu.scss
+++ b/src/jigsaw/pc-components/menu/navigation-menu.scss
@@ -275,6 +275,7 @@ $jigsaw-nav-menu: #{$jigsaw-prefix}-nav-menu;
 
                         &.#{$jigsaw-nav-menu}-sub-item-selected {
                             background-color: #212a33;
+                            color: $font-color-white;
                         }
                     }
                 }


### PR DESCRIPTION
Change-Id: I461249bc7dfb65302a4760842ab728e287b0cd21

![image](https://user-images.githubusercontent.com/41236821/163549564-98f88af5-27bc-47e3-a0d7-c8a5e78fce81.png)
