### PR TITLE
[故障]  解决了分组下拉框无法清空已选择的值的问题，关联@6301

### DIFF
--- a/src/app/demo/pc/select-group/edit-selected-items/demo.component.html
+++ b/src/app/demo/pc/select-group/edit-selected-items/demo.component.html
@@ -9,3 +9,4 @@
 
 <jigsaw-button (click)="editSelectedItems()">修改选中条目</jigsaw-button>
 <jigsaw-button (click)="changeData()">修改输入数据</jigsaw-button>
+<jigsaw-button (click)="clearSelectedItems()">清除已选数据</jigsaw-button>

--- a/src/app/demo/pc/select-group/edit-selected-items/demo.component.ts
+++ b/src/app/demo/pc/select-group/edit-selected-items/demo.component.ts
@@ -36,6 +36,10 @@ export class SelectGroupEditResultDemoComponent {
         this.selectedOption.refresh();
     }
 
+    clearSelectedItems() {
+        this.selectedOption = undefined;
+    }
+
     index = 0;
 
     changeData() {

--- a/src/jigsaw/pc-components/select/select-base.ts
+++ b/src/jigsaw/pc-components/select/select-base.ts
@@ -657,6 +657,9 @@ export abstract class JigsawSelectGroupBase extends JigsawSelectBase {
             return;
         }
         if (CommonUtils.isUndefined(newValue)) {
+            this.runMicrotask(() => {
+                this._$handleClearable();
+            })
             return;
         }
         if (!(newValue instanceof Array || newValue instanceof ArrayCollection)) {


### PR DESCRIPTION
Change-Id: Ic0f880bc620a48a872be184852b0185f70cf8134

http://localhost:4200/#/pc/select-group/edit-selected-items