### PR TITLE
[优化] 优化input组件的prefix-suffix 文本过长时把下拉箭头挤掉的问题，关联了@6585

### DIFF
--- a/src/jigsaw/pc-components/input/prefix-suffix-widget.scss
+++ b/src/jigsaw/pc-components/input/prefix-suffix-widget.scss
@@ -24,6 +24,7 @@ $prefix-suffix-cls: #{$jigsaw-prefix}-prefix-suffix;
             display: flex;
             align-items: center;
             justify-content: center;
+            width: 80%;
 
             &-text {
                 flex: 1;

--- a/src/jigsaw/pc-components/input/prefix-suffix-widget.scss
+++ b/src/jigsaw/pc-components/input/prefix-suffix-widget.scss
@@ -24,7 +24,7 @@ $prefix-suffix-cls: #{$jigsaw-prefix}-prefix-suffix;
             display: flex;
             align-items: center;
             justify-content: center;
-            width: 80%;
+            width: calc(100% - 14px);
 
             &-text {
                 flex: 1;


### PR DESCRIPTION
Change-Id: I5562db5b3ac605bf28ae7b099b3124da0c74d808

![image](https://user-images.githubusercontent.com/41236821/165757250-35265069-0f31-4d5c-a3b0-63ae424f962a.png)
