### PR TITLE
[优化] zjcm皮肤的radio选中状态原点位置优化，关联了@6250

### DIFF
--- a/src/jigsaw/common/core/theming/prebuilt/settings/zjcm-reset.scss
+++ b/src/jigsaw/common/core/theming/prebuilt/settings/zjcm-reset.scss
@@ -34,14 +34,17 @@
 .jigsaw-radios-host {
     .jigsaw-radio-option {
         .jigsaw-radio-option-inner {
+            width: 16px;
+            height: 16px;
+
             &:after {
                 content: " ";
                 position: absolute;
-                width: 6px;
-                height: 6px;
+                width: 8px;
+                height: 8px;
                 left: 3px;
                 top: 3px;
-                border-radius: 4px;
+                border-radius: 8px;
                 display: table;
                 border-top: 0;
                 border-left: 0;
@@ -56,7 +59,7 @@
                 border-color: $brand-default;
 
                 &:after {
-                    @include prefixer(transform, scale(1.4));
+                    @include prefixer(transform, scale(1));
                     @include prefixer(transition, all 0.3s $ease-in-out-circ);
                     opacity: 1;
                 }


### PR DESCRIPTION
Change-Id: I4251cd77ac7701fce71cd5c613bcaff39b89c5a7

![image](https://user-images.githubusercontent.com/41236821/167249997-60073f68-d171-454c-a051-dc288be8611d.png)
