### PR TITLE
[修复] 修复group-select/collapse-select组件手动修改已选项时，不会清理之前已选项的问题，关联了@6246

### DIFF
--- a/src/app/demo/pc/select-group/edit-selected-items/demo.component.html
+++ b/src/app/demo/pc/select-group/edit-selected-items/demo.component.html
@@ -2,11 +2,21 @@
 <jigsaw-demo-description [summary]="summary" [content]="description"></jigsaw-demo-description>
 
 <!-- start to learn the demo from here -->
-<jigsaw-group-select [data]="dataList" [(value)]="selectedOption" [multipleSelect]="true" [clearable]="true"
-                     placeholder="请选择" width="160px" [useStatistics]="true" (valueChange)="valueChange($event)"
-                     optionCount="20">
+<jigsaw-header>多选</jigsaw-header>
+<jigsaw-group-select [data]="dataList" [(value)]="selectedOptions" [multipleSelect]="true" [clearable]="true"
+    placeholder="请选择" width="160px" [useStatistics]="true" (valueChange)="valueChange($event)" optionCount="20">
 </jigsaw-group-select>
 
-<jigsaw-button (click)="editSelectedItems()">修改选中条目</jigsaw-button>
-<jigsaw-button (click)="changeData()">修改输入数据</jigsaw-button>
+<jigsaw-button (click)="changeSelectedItems('multiple')">修改已选数据</jigsaw-button>
 <jigsaw-button (click)="clearSelectedItems()">清除已选数据</jigsaw-button>
+<jigsaw-button (click)="editSelectedItems()">编辑选中条目</jigsaw-button>
+<jigsaw-button (click)="changeData()">修改输入数据</jigsaw-button>
+<jigsaw-button (click)="resetData('multiple')">重置输入数据</jigsaw-button>
+
+<jigsaw-header>单选</jigsaw-header>
+<jigsaw-group-select [data]="dataList2" [(value)]="selectedOption" [multipleSelect]="false" [clearable]="true"
+    placeholder="请选择" width="160px" (valueChange)="valueChange($event)" optionCount="20">
+</jigsaw-group-select>
+
+<jigsaw-button (click)="changeSelectedItems('single')">修改已选数据</jigsaw-button>
+<jigsaw-button (click)="resetData('single')">重置输入数据</jigsaw-button>

--- a/src/app/demo/pc/select-group/edit-selected-items/demo.component.html
+++ b/src/app/demo/pc/select-group/edit-selected-items/demo.component.html
@@ -3,13 +3,13 @@
 
 <!-- start to learn the demo from here -->
 <jigsaw-header>多选</jigsaw-header>
-<jigsaw-group-select [data]="dataList" [(value)]="selectedOptions" [multipleSelect]="true" [clearable]="true"
-    placeholder="请选择" width="160px" [useStatistics]="true" (valueChange)="valueChange($event)" optionCount="20">
+<jigsaw-group-select #selectGroup [data]="dataList" [(value)]="selectedOptions" [multipleSelect]="true" [clearable]="true"
+    placeholder="请选择" width="160px" [useStatistics]="false" (valueChange)="valueChange($event)" optionCount="20">
 </jigsaw-group-select>
 
 <jigsaw-button (click)="changeSelectedItems('multiple')">修改已选数据</jigsaw-button>
 <jigsaw-button (click)="clearSelectedItems()">清除已选数据</jigsaw-button>
-<jigsaw-button (click)="editSelectedItems()">编辑选中条目</jigsaw-button>
+<jigsaw-button (click)="editSelectedItems('multiple')">编辑选中条目</jigsaw-button>
 <jigsaw-button (click)="changeData()">修改输入数据</jigsaw-button>
 <jigsaw-button (click)="resetData('multiple')">重置输入数据</jigsaw-button>
 
@@ -19,4 +19,5 @@
 </jigsaw-group-select>
 
 <jigsaw-button (click)="changeSelectedItems('single')">修改已选数据</jigsaw-button>
+<jigsaw-button (click)="editSelectedItems('single')">编辑选中条目</jigsaw-button>
 <jigsaw-button (click)="resetData('single')">重置输入数据</jigsaw-button>

--- a/src/app/demo/pc/select-group/edit-selected-items/demo.component.ts
+++ b/src/app/demo/pc/select-group/edit-selected-items/demo.component.ts
@@ -1,11 +1,14 @@
-import { Component } from "@angular/core";
-import { ArrayCollection } from "jigsaw/public_api";
+import { Component, ViewChild } from "@angular/core";
+import { ArrayCollection, JigsawSelectGroup } from "jigsaw/public_api";
 
 @Component({
     templateUrl: "./demo.component.html"
 })
 export class SelectGroupEditResultDemoComponent {
-    data = [
+    @ViewChild('selectGroup')
+    private _selectGroup: JigsawSelectGroup;
+
+    dataList = new ArrayCollection([
         { groupName: "分组标题1", data: [{ label: "文本选项1文本选项1文本选项1文本选项1文本选项1" }, { label: "文本选项2" }, { label: "文本选项3" }] },
         {
             groupName: "分组标题2",
@@ -16,11 +19,20 @@ export class SelectGroupEditResultDemoComponent {
             ]
         },
         { groupName: "分组标题3", data: [{ label: "文本选项7" }, { label: "文本选项8" }, { label: "文本选项9" }] }
-    ];
+    ]);
 
-    dataList = new ArrayCollection(this.data);
-
-    dataList2 = new ArrayCollection(this.data);
+    dataList2 = new ArrayCollection([
+        { groupName: "分组标题1", data: [{ label: "文本选项1文本选项1文本选项1文本选项1文本选项1" }, { label: "文本选项2" }, { label: "文本选项3" }] },
+        {
+            groupName: "分组标题2",
+            data: [
+                { label: "禁用选项4", disabled: true },
+                { label: "禁用选项5", disabled: true },
+                { label: "文本选项6" }
+            ]
+        },
+        { groupName: "分组标题3", data: [{ label: "文本选项7" }, { label: "文本选项8" }, { label: "文本选项9" }] }
+    ]);
 
     selectedOptions = new ArrayCollection([
         { groupName: "分组标题1", data: [{ label: "文本选项2" }, { label: "文本选项3" }] },
@@ -35,13 +47,23 @@ export class SelectGroupEditResultDemoComponent {
         console.log($event);
     }
 
-    editSelectedItems() {
-        this.selectedOptions.forEach((groupItem, i) => {
+    editSelectedItems(type) {
+        let data;
+        switch (type) {
+            case 'single':
+                data = this.selectedOption;
+                break;
+            case 'multiple':
+            default:
+                data = this.selectedOptions;
+        }
+        data.forEach((groupItem, i) => {
             groupItem.data.forEach((item, j) => {
                 item.label = `修改结果-${i}-${j}`;
             });
         });
-        this.selectedOptions.refresh();
+        data.refresh();
+        this._selectGroup.refresh();
     }
 
     clearSelectedItems() {
@@ -66,11 +88,33 @@ export class SelectGroupEditResultDemoComponent {
     resetData(type: string) {
         switch (type) {
             case 'single':
-                this.dataList2 = new ArrayCollection(this.data);
+                this.dataList2 = new ArrayCollection([
+                    { groupName: "分组标题1", data: [{ label: "文本选项1文本选项1文本选项1文本选项1文本选项1" }, { label: "文本选项2" }, { label: "文本选项3" }] },
+                    {
+                        groupName: "分组标题2",
+                        data: [
+                            { label: "禁用选项4", disabled: true },
+                            { label: "禁用选项5", disabled: true },
+                            { label: "文本选项6" }
+                        ]
+                    },
+                    { groupName: "分组标题3", data: [{ label: "文本选项7" }, { label: "文本选项8" }, { label: "文本选项9" }] }
+                ]);
                 break;
             case 'multiple':
             default:
-                this.dataList = new ArrayCollection(this.data);
+                this.dataList = new ArrayCollection([
+                    { groupName: "分组标题1", data: [{ label: "文本选项1文本选项1文本选项1文本选项1文本选项1" }, { label: "文本选项2" }, { label: "文本选项3" }] },
+                    {
+                        groupName: "分组标题2",
+                        data: [
+                            { label: "禁用选项4", disabled: true },
+                            { label: "禁用选项5", disabled: true },
+                            { label: "文本选项6" }
+                        ]
+                    },
+                    { groupName: "分组标题3", data: [{ label: "文本选项7" }, { label: "文本选项8" }, { label: "文本选项9" }] }
+                ]);
         }
     }
 

--- a/src/app/demo/pc/select-group/edit-selected-items/demo.component.ts
+++ b/src/app/demo/pc/select-group/edit-selected-items/demo.component.ts
@@ -5,7 +5,7 @@ import { ArrayCollection } from "jigsaw/public_api";
     templateUrl: "./demo.component.html"
 })
 export class SelectGroupEditResultDemoComponent {
-    dataList = new ArrayCollection([
+    data = [
         { groupName: "分组标题1", data: [{ label: "文本选项1文本选项1文本选项1文本选项1文本选项1" }, { label: "文本选项2" }, { label: "文本选项3" }] },
         {
             groupName: "分组标题2",
@@ -16,11 +16,19 @@ export class SelectGroupEditResultDemoComponent {
             ]
         },
         { groupName: "分组标题3", data: [{ label: "文本选项7" }, { label: "文本选项8" }, { label: "文本选项9" }] }
+    ];
+
+    dataList = new ArrayCollection(this.data);
+
+    dataList2 = new ArrayCollection(this.data);
+
+    selectedOptions = new ArrayCollection([
+        { groupName: "分组标题1", data: [{ label: "文本选项2" }, { label: "文本选项3" }] },
+        { groupName: "分组标题2", data: [{ label: "文本选项6" }] }
     ]);
 
     selectedOption = new ArrayCollection([
-        { groupName: "分组标题1", data: [{ label: "文本选项2" }, { label: "文本选项3" }] },
-        { groupName: "分组标题2", data: [{ label: "文本选项6" }] }
+        { groupName: "分组标题1", data: [{ label: "文本选项2" }] }
     ]);
 
     valueChange($event) {
@@ -28,16 +36,42 @@ export class SelectGroupEditResultDemoComponent {
     }
 
     editSelectedItems() {
-        this.selectedOption.forEach((groupItem, i) => {
+        this.selectedOptions.forEach((groupItem, i) => {
             groupItem.data.forEach((item, j) => {
                 item.label = `修改结果-${i}-${j}`;
             });
         });
-        this.selectedOption.refresh();
+        this.selectedOptions.refresh();
     }
 
     clearSelectedItems() {
-        this.selectedOption = undefined;
+        this.selectedOptions = undefined;
+    }
+
+    changeSelectedItems(type) {
+        switch (type) {
+            case 'single':
+                this.selectedOption = new ArrayCollection([
+                    { groupName: "分组标题3", data: [{ label: "文本选项7" }] }
+                ]);
+                break;
+            case 'multiple':
+            default:
+                this.selectedOptions = new ArrayCollection([
+                    { groupName: "分组标题3", data: [{ label: "文本选项7" }, { label: "文本选项8" }, { label: "文本选项9" }] }
+                ]);
+        }
+    }
+
+    resetData(type: string) {
+        switch (type) {
+            case 'single':
+                this.dataList2 = new ArrayCollection(this.data);
+                break;
+            case 'multiple':
+            default:
+                this.dataList = new ArrayCollection(this.data);
+        }
     }
 
     index = 0;

--- a/src/jigsaw/pc-components/combo-select/combo-select.ts
+++ b/src/jigsaw/pc-components/combo-select/combo-select.ts
@@ -61,7 +61,7 @@ export class JigsawComboSelect extends AbstractJigsawComponent implements Contro
                 protected _zone: NgZone,
                 // @RequireMarkForCheck 需要用到，勿删
                 private _injector: Injector,
-                private _cdr: ChangeDetectorRef) {
+                public _$cdr: ChangeDetectorRef) {
         super(_zone);
     }
 
@@ -440,7 +440,7 @@ export class JigsawComboSelect extends AbstractJigsawComponent implements Contro
         if (value && this._value != value) {
             // 初始表单值的赋值
             this._value = value instanceof ArrayCollection ? value : new ArrayCollection(value);
-            this._cdr.markForCheck();
+            this._$cdr.markForCheck();
         }
         if (emit) {
             this.runMicrotask(() => this.valueChange.emit(this._value));

--- a/src/jigsaw/pc-components/select/collapse-and-group-select.html
+++ b/src/jigsaw/pc-components/select/collapse-and-group-select.html
@@ -1,4 +1,4 @@
-<jigsaw-combo-select width="100%" [theme]="theme" [autoWidth]="!optionWidth" [maxHeight]="maxHeight" [(value)]="_$selectedItems"
+<jigsaw-combo-select #comboSelect width="100%" [theme]="theme" [autoWidth]="!optionWidth" [maxHeight]="maxHeight" [(value)]="_$selectedItems"
                      [clearable]="clearable" [labelField]="labelField" [valid]="valid" [disabled]="disabled"
                      [placeholder]="placeholder" [openTrigger]="openTrigger" [closeTrigger]="closeTrigger"
                      [autoClose]="!multipleSelect" (openChange)="_$onComboOpenChange($event)"

--- a/src/jigsaw/pc-components/select/select-base.ts
+++ b/src/jigsaw/pc-components/select/select-base.ts
@@ -1,11 +1,12 @@
-import {ChangeDetectorRef, Directive, EventEmitter, Injector, Input, NgZone, OnDestroy, Output, ViewChild, Renderer2, ElementRef} from "@angular/core";
-import {ControlValueAccessor} from "@angular/forms";
-import {PerfectScrollbarDirective} from 'ngx-perfect-scrollbar';
-import {AbstractJigsawComponent, IJigsawFormControl} from "../../common/common";
-import {ArrayCollection, LocalPageableArray, PageableArray} from "../../common/core/data/array-collection";
-import {CallbackRemoval, CommonUtils} from "../../common/core/utils/common-utils";
-import {RequireMarkForCheck} from "../../common/decorator/mark-for-check";
-import {CheckBoxStatus} from "../checkbox/typings";
+import { ChangeDetectorRef, Directive, EventEmitter, Injector, Input, NgZone, OnDestroy, Output, ViewChild, Renderer2, ElementRef } from "@angular/core";
+import { ControlValueAccessor } from "@angular/forms";
+import { PerfectScrollbarDirective } from 'ngx-perfect-scrollbar';
+import { AbstractJigsawComponent, IJigsawFormControl } from "../../common/common";
+import { ArrayCollection, LocalPageableArray, PageableArray } from "../../common/core/data/array-collection";
+import { CallbackRemoval, CommonUtils } from "../../common/core/utils/common-utils";
+import { RequireMarkForCheck } from "../../common/decorator/mark-for-check";
+import { CheckBoxStatus } from "../checkbox/typings";
+import { JigsawComboSelect } from '../combo-select';
 
 export type SelectOption = {
     disabled?: boolean;
@@ -570,6 +571,9 @@ export type GroupSelectOption = {
 }
 @Directive()
 export abstract class JigsawSelectGroupBase extends JigsawSelectBase {
+    @ViewChild('comboSelect')
+    private _comboSelect: JigsawComboSelect;
+
     /**
      * 设置组名的显示字段
      *
@@ -615,7 +619,7 @@ export abstract class JigsawSelectGroupBase extends JigsawSelectBase {
     private _setEmptyValue(value: ArrayCollection<GroupSelectOption> | GroupSelectOption[] | LocalPageableArray<GroupSelectOption> | PageableArray): void {
         this._$listValue = new ArrayCollection([]);
         value.forEach(groupData => {
-            this._$listValue.push({[this.groupField]: groupData[this.groupField], data: new ArrayCollection([])})
+            this._$listValue.push({ [this.groupField]: groupData[this.groupField], data: new ArrayCollection([]) })
         });
         this._$selectedItems = [];
     }
@@ -711,6 +715,8 @@ export abstract class JigsawSelectGroupBase extends JigsawSelectBase {
         this._changeDetector.markForCheck();
     }
 
+    private _removeOnRefreshListener: CallbackRemoval;
+
     private _updateValue(): void {
         this._$selectedItems = [];
         this._value = new ArrayCollection([]);
@@ -720,6 +726,13 @@ export abstract class JigsawSelectGroupBase extends JigsawSelectBase {
                 this._value.push(groupData);
             }
         });
+        if (this._removeOnRefreshListener) {
+            this._removeOnRefreshListener();
+            this._removeOnRefreshListener = null;
+        }
+        this._removeOnRefreshListener = this._value.onRefresh(() => {
+            this._comboSelect._$cdr.markForCheck();
+        })
     }
 
     private _updateSelectedItems(): void {
@@ -769,5 +782,16 @@ export abstract class JigsawSelectGroupBase extends JigsawSelectBase {
         this._updateSelectedItems();
         this._$checkSelectAll();
         this.remove.emit(removedItem);
+    }
+
+    ngOnDestroy() {
+        super.ngOnDestroy();
+        if (this._removeOnRefresh) {
+            this._removeOnRefresh();
+        }
+        if (this._removeOnRefreshListener) {
+            this._removeOnRefreshListener();
+            this._removeOnRefreshListener = null;
+        }
     }
 }

--- a/src/jigsaw/pc-components/select/select-base.ts
+++ b/src/jigsaw/pc-components/select/select-base.ts
@@ -674,6 +674,8 @@ export abstract class JigsawSelectGroupBase extends JigsawSelectBase {
             return;
         }
 
+        this._setEmptyValue(this.data);
+
         this.runMicrotask(() => {
             newValue.forEach((groupData: GroupSelectOption) => {
                 const srcData = this._data.find(dataItem => dataItem[this.groupField] === groupData[this.groupField]).data;


### PR DESCRIPTION
Change-Id: I9eb02dd7170d56decf2a59f366c43fd6e5d9048c

http://localhost:4200/#/pc/select-group/edit-selected-items