### PR TITLE
[优化] toast组件默认宽度对齐规范至256px；解决组件圆角有误的问题；关联了@6187

### DIFF
--- a/src/app/demo/pc/toast/full/demo.component.ts
+++ b/src/app/demo/pc/toast/full/demo.component.ts
@@ -10,7 +10,7 @@ export class ToastFullDemoComponent {
     message = '这是一个Toast提示框！';
     icon = undefined;
     timeout = 80;
-    width = 200;
+    width = 256;
 
     show() {
         JigsawToast.show(this.message, { icon: this.icon, timeout: this.timeout * 1000, width: this.width })

--- a/src/jigsaw/pc-components/toast/toast.scss
+++ b/src/jigsaw/pc-components/toast/toast.scss
@@ -5,9 +5,10 @@ $jigsaw-toast: #{$jigsaw-prefix}-toast;
         display: flex;
         align-items: center;
         width: 100%;
-        min-width: 200px;
+        min-width: 256px;
         height: $height-huge;
         background: $bg-popup;
+        border-radius: $border-radius-base;
 
         .#{$jigsaw-toast}-icon {
             display: flex;

--- a/src/jigsaw/pc-components/toast/toast.ts
+++ b/src/jigsaw/pc-components/toast/toast.ts
@@ -131,7 +131,7 @@ export class JigsawToast extends AbstractDialogComponentBase implements OnDestro
             return;
         }
         const opt: ToastMessage = options ? options : {};
-        opt.width = opt.hasOwnProperty('width') ? (opt.width > 200 ? opt.width : 200) : 200;
+        opt.width = opt.hasOwnProperty('width') ? (opt.width > 256 ? opt.width : 256) : 256;
         opt.timeout = +opt.timeout >= 0 ? +opt.timeout : 8000;
 
         const popupOptions = {


### PR DESCRIPTION
Change-Id: Ia2c63a78a01f5660706dd3e50f35cc56555b2c55

![image](https://user-images.githubusercontent.com/41236821/170178036-ef9c2166-1220-4f16-83aa-3d9db3c5ed08.png)
