### PR TITLE
[故障] 解决树节点改名后进行搜索时，未及时更新节点名导致搜索结果出错的问题，关联了@6179

### DIFF
--- a/src/jigsaw/pc-components/tree/tree-ext.ts
+++ b/src/jigsaw/pc-components/tree/tree-ext.ts
@@ -697,6 +697,9 @@ export class JigsawTreeExt extends AbstractJigsawComponent implements AfterViewI
         // reset node label
         nodes.filter(node => CommonUtils.isDefined(node?.oldname) && node?.oldname != node[field])
             .forEach(node => {
+                if (!node[field].includes('jigsaw-tree-funzzy-search-identification')) {
+                    return;
+                }
                 node[field] = node.oldname;
                 this.ztree.updateNode(node);
             });
@@ -714,7 +717,7 @@ export class JigsawTreeExt extends AbstractJigsawComponent implements AfterViewI
                 node.oldname = node[field];
                 const rexGlobal = new RegExp(regKeywords, 'gi');
                 node[field] = node.oldname.replace(rexGlobal, originalText =>
-                    `<span style="background-color: var(--primary-disabled);">${originalText}</span>`);
+                    `<span class="jigsaw-tree-funzzy-search-identification" style="background-color: var(--primary-disabled);">${originalText}</span>`);
                 this.ztree.updateNode(node);
                 this.ztree.showNode(node);
 


### PR DESCRIPTION
Change-Id: Ia893954c92e49d9586b8a5921d8ae79fc9c8ff93

