### PR TITLE
[故障] 解决linux云桌面Google浏览器89.x版本下，表格的行高和标题高度不正确的问题，关联了@6090

### DIFF
--- a/src/jigsaw/pc-components/table/table.scss
+++ b/src/jigsaw/pc-components/table/table.scss
@@ -12,7 +12,6 @@ $jigsaw-table: #{$jigsaw-prefix}-table;
 
         tr {
             td {
-                height: 100%;
                 color: $font-color-default;
                 border-width: 1px;
                 border-style: solid;
@@ -97,7 +96,6 @@ $jigsaw-table: #{$jigsaw-prefix}-table;
                 height: 32px;
 
                 td {
-                    height: 100%;
                     background: $bg-gray;
 
                     .#{$jigsaw-table}-header-cell {


### PR DESCRIPTION
Change-Id: Ic46ae7ebc001a70672cb8f454886912a6f11f51e

![image](https://user-images.githubusercontent.com/41236821/176392368-cb96aefa-54b2-4a92-956b-3ba8406b291b.png)
