### PR TITLE
[优化] Breadcrumb组件左边蓝色文字部分字号改为12px，关联了@5998

### DIFF
--- a/src/jigsaw/pc-components/breadcrumb/breadcrumb.scss
+++ b/src/jigsaw/pc-components/breadcrumb/breadcrumb.scss
@@ -68,29 +68,37 @@ $jigsaw-breadcrumb: #{$jigsaw-prefix}-breadcrumb;
         padding: 0 8px;
         font-size: $font-size-base;
         background: $bg-component;
+
         .#{$jigsaw-breadcrumb}-item {
             .#{$jigsaw-breadcrumb}-icon {
                 color: $brand-default;
             }
+
             .#{$jigsaw-breadcrumb}-label {
                 color: $brand-default;
+                font-size: $font-size-base;
+
                 &:hover {
                     text-decoration: underline;
                 }
+
                 &:active {
                     color: $brand-active;
                 }
             }
+
             &.#{$jigsaw-breadcrumb}-current {
-                font-size: $font-title-lg;
                 font-weight: bold;
                 color: $font-color-heading-bold;
                 padding-bottom: 4px;
+
                 .#{$jigsaw-breadcrumb}-icon {
                     color: $font-color-heading-bold;
                 }
+
                 .#{$jigsaw-breadcrumb}-label {
                     color: $font-color-heading-bold;
+                    font-size: $font-title-lg;
                     text-decoration: none;
                 }
             }


### PR DESCRIPTION
Change-Id: I3273f32fad846cb07fa4a082a0c0cddd98569255
![image](https://user-images.githubusercontent.com/41236821/183335081-ff8987f9-1397-43f3-ac9c-39ae09be4013.png)
