### PR TITLE
[故障] 解决上传组件在单选时，无法手动上传的问题，解决了@5979

### DIFF
--- a/src/jigsaw/common/directive/upload/upload.directive.ts
+++ b/src/jigsaw/common/directive/upload/upload.directive.ts
@@ -203,6 +203,7 @@ export class JigsawUploadDirective extends JigsawUploadBase implements IUploader
             this._fileInputElement.setAttribute('multiple', 'true');
         } else {
             this._fileInputElement.removeAttribute('multiple');
+            this.clear();
         }
         this._fileInputElement.setAttribute('accept', this.fileType);
 
@@ -224,10 +225,6 @@ export class JigsawUploadDirective extends JigsawUploadBase implements IUploader
             return false;
         }
         const files = this._checkFiles(Array.from(fileInput.files || []));
-        if (!this.multiple) {
-            this.files.splice(0, this.files.length);
-            files.splice(1, files.length);
-        }
         fileInput.value = null;
         this.files.push(...files);
         if (files.length > 0) {

--- a/src/jigsaw/common/directive/upload/upload.directive.ts
+++ b/src/jigsaw/common/directive/upload/upload.directive.ts
@@ -203,12 +203,14 @@ export class JigsawUploadDirective extends JigsawUploadBase implements IUploader
             this._fileInputElement.setAttribute('multiple', 'true');
         } else {
             this._fileInputElement.removeAttribute('multiple');
-            this.clear();
         }
         this._fileInputElement.setAttribute('accept', this.fileType);
 
         this._removeFileChangeEvent = this._removeFileChangeEvent ? this._removeFileChangeEvent :
             this._renderer.listen(this._fileInputElement, 'change', () => {
+                if (!this.multiple) {
+                    this.clear();
+                }
                 if (this.uploadImmediately) {
                     this.upload();
                 } else {
@@ -367,6 +369,10 @@ export class JigsawUploadDirective extends JigsawUploadBase implements IUploader
 
     private _afterCurFileUploaded(fileInfo: UploadFileInfo) {
         this.progress.emit(fileInfo);
+
+        if (!this.multiple) {
+            return;
+        }
 
         const waitingFile = this.files.find(f => f.state == 'pause');
         if (waitingFile) {


### PR DESCRIPTION
Change-Id: I593b4150d5b679a9ce5ac9e572fe8eac96d4da09

原先的_appendFiles()会在_selectFile和upload时执行，但是在multiple为false的情况下，方法对外部有影响。固把clear方法提到upload之外。