### PR TITLE
[故障] 通用图形初始化后设置空option，图形不能切到无数据的图标，关联@5924

### DIFF
--- a/src/jigsaw/pc-components/graph/graph.ts
+++ b/src/jigsaw/pc-components/graph/graph.ts
@@ -54,6 +54,7 @@ export class JigsawGraph extends AbstractJigsawComponent implements OnInit, OnDe
         if (this._$dataValid) {
             this.resize();
         }
+        this._changeDetectorRef.markForCheck();
     }
 
     // 通过 echarts.init 创建的实例


### PR DESCRIPTION
Change-Id: I6031406666fbb17b7486bb495c459e1a0cdef94a