### PR TITLE
[故障] 解决search-input在通过双绑数据置空时无效的问题，解决了@5810

### DIFF
--- a/src/app/for-internal/demo/pc/search-input/basic/demo.component.html
+++ b/src/app/for-internal/demo/pc/search-input/basic/demo.component.html
@@ -3,14 +3,14 @@
 
 <!-- start to learn the demo from here -->
 
+<a (click)="clear()">清空搜索框内容</a>
+
 <jigsaw-header>自动搜索</jigsaw-header>
-<jigsaw-search-input width="200px" (search)="value1 = $event" [searchDebounce]="1000">
-</jigsaw-search-input><div>
-    {{ " 搜索值为：" + value1 }}
-</div>
+<jigsaw-search-input width="200px" [(value)]="value1" (search)="value1 = $event" [searchDebounce]="1000">
+</jigsaw-search-input>
+<div> {{ " 搜索值为：" + value1 }} </div>
 
 <jigsaw-header>手动搜索</jigsaw-header>
-<jigsaw-search-input width="200px" [autoSearch]="false" (search)="value2 = $event">
-</jigsaw-search-input><div>
-    {{ " 搜索值为：" + value2 }}
-</div>
+<jigsaw-search-input width="200px" [(value)]="value2" [autoSearch]="false" (search)="value2 = $event">
+</jigsaw-search-input>
+<div> {{ " 搜索值为：" + value2 }} </div>

--- a/src/app/for-internal/demo/pc/search-input/basic/demo.component.ts
+++ b/src/app/for-internal/demo/pc/search-input/basic/demo.component.ts
@@ -8,6 +8,11 @@ export class SearchInputBasicDemoComponent {
     value1: string;
     value2: string;
 
+    clear() {
+        this.value1 = '';
+        this.value2 = '';
+    }
+
     // ====================================================================
     // ignore the following lines, they are not important to this demo
     // ====================================================================

--- a/src/jigsaw/pc-components/input/search-input.ts
+++ b/src/jigsaw/pc-components/input/search-input.ts
@@ -97,6 +97,7 @@ export class JigsawSearchInput extends AbstractJigsawComponent implements Contro
             return;
         }
         this._value = newValue.trim();
+        this.valueChange.emit(this._value);
         // 表单友好接口
         this._propagateChange(this._value);
     }


### PR DESCRIPTION
Change-Id: Ie9bee329b7ff1bb4089aec732674959c567bbe0b
http://localhost:4200/#/pc/search-input/basic