### PR TITLE
[优化] 解决input组件设置背景色有锯齿的问题，关联了@5606

### DIFF
--- a/src/jigsaw/pc-components/input/input.scss
+++ b/src/jigsaw/pc-components/input/input.scss
@@ -4,6 +4,7 @@ $jigsaw-input: #{$jigsaw-prefix}-input;
     @include inline-block();
     height: $height-base;
     font-size: $font-size-text-base;
+    border-radius: $border-radius-base;
     overflow: hidden;
 
     .#{$jigsaw-input}-container {


### PR DESCRIPTION
上个pr漏改组件
![image](https://user-images.githubusercontent.com/41236821/207814944-36b272e1-5281-457c-9647-4119c0684cf5.png)
