### PR TITLE
[故障] 解决上传组件里的“重新上传”词条未国际化的问题，解决了@5412

### DIFF
--- a/src/jigsaw/pc-components/upload/index.ts
+++ b/src/jigsaw/pc-components/upload/index.ts
@@ -31,6 +31,7 @@ export class JigsawUploadModule {
                 "uploading": "上传中",
                 "done": "上传成功",
                 "failed": "上传失败",
+                "retry": "重新上传",
                 "unknownStatus": "未知状态",
 
                 "Bad Request": "错误详情：错误请求",
@@ -95,6 +96,7 @@ export class JigsawUploadModule {
                 "uploading": "Uploading",
                 "done": "Success to upload",
                 "failed": "Failed to upload",
+                "retry": "Retry",
                 "unknownStatus": "Unknown status",
 
                 "Bad Request": "Error detail: Bad Request",

--- a/src/jigsaw/pc-components/upload/upload-result.html
+++ b/src/jigsaw/pc-components/upload/upload-result.html
@@ -22,7 +22,7 @@
                 status="processing"
             ></jigsaw-progress>
             <span class="jigsaw-upload-result-re-upload" *ngIf="!_$checkRetry(file) && file.state === 'error'"
-                  (click)="_$retryUpload(file)">重新上传</span>
+                  (click)="_$retryUpload(file)">{{'upload.retry' | translate }}</span>
             <ul>
                 <li *ngFor="let log of file.log">
                     <span class="detail-time" [jigsawTooltip]="log.time">{{log.time.split(" ")[1]}}</span>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41236821/215690630-ee02ee83-ac52-4163-87cd-84358066ae43.png)
