### PR TITLE
[优化] 输入框、下拉框对齐规范；图标颜色对齐规范；解决了@6926

### DIFF
--- a/src/jigsaw/common/core/theming/prebuilt/settings/vmax-pro-light.scss
+++ b/src/jigsaw/common/core/theming/prebuilt/settings/vmax-pro-light.scss
@@ -283,8 +283,8 @@ $border-color-shadow-cntr: transparent;
 /*@public*/ $splitline-default: $gray-4;
 
 /* icon 图标 */
-/*@public*/ $icon-color-default: $gray-6;
-/*@public*/ $icon-color-disabled: $gray-4;
+/*@public*/ $icon-color-default: $gray-8;
+/*@public*/ $icon-color-disabled: $gray-6;
 /*@public*/ $icon-color-stress: $gray-8;
 
 /* box-shadow 阴影（基于altitude）

--- a/src/jigsaw/pc-components/date-and-time/time-picker.scss
+++ b/src/jigsaw/pc-components/date-and-time/time-picker.scss
@@ -13,7 +13,7 @@ $jigsaw-time-picker: #{$jigsaw-prefix}-time-picker;
     color: $font-color-default;
     font-size: $font-size-base;
     overflow: hidden;
-    padding: 4px 34px 4px 8px;
+    padding: 4px 34px 4px 0px;
 
     &:hover,
     &.#{$jigsaw-time-picker}-active {
@@ -26,6 +26,7 @@ $jigsaw-time-picker: #{$jigsaw-prefix}-time-picker;
         justify-content: center;
         align-items: center;
         height: 100%;
+        padding-left: 8px;
 
         input {
             @include inline-block();

--- a/src/jigsaw/pc-components/input/input.scss
+++ b/src/jigsaw/pc-components/input/input.scss
@@ -64,6 +64,10 @@ $jigsaw-input: #{$jigsaw-prefix}-input;
         border-style: solid;
         border-color: $brand-default;
     }
+    
+    &.#{$jigsaw-input}-focused .#{$jigsaw-input}-wrapper {
+        border-color: $brand-active;
+    }
 
     &.#{$jigsaw-input}-disabled {
         .#{$jigsaw-input}-wrapper {

--- a/src/jigsaw/pc-components/select/select-base.ts
+++ b/src/jigsaw/pc-components/select/select-base.ts
@@ -399,11 +399,11 @@ export abstract class JigsawSelectBase extends AbstractJigsawComponent implement
     /**
      * @internal
      */
-    public _$showAllStatistics(): boolean {
+    public _$showAllStatistics(validData?: SelectOption[]): boolean {
         if (!this.multipleSelect || !this.useStatistics || !this._$selectedItems || !this._$selectedItems.length) {
             return false
         }
-        const validData = this._getValidData();
+        validData = validData || this._getValidData();
         if (this.searchable) {
             return this._$selectedItems.length === validData.length && !this._searchKey;
         } else {
@@ -415,10 +415,14 @@ export abstract class JigsawSelectBase extends AbstractJigsawComponent implement
      * @internal
      */
     public _$showNumStatistics(): boolean {
-        if (!this.multipleSelect || !this.useStatistics || !this._$selectedItems || !this._getValidData().length || !this._$selectedItems.length) {
-            return false
+        if (!this.multipleSelect || !this.useStatistics || !this._$selectedItems || !this._$selectedItems.length) {
+            return false;
         }
-        return !this._$showAllStatistics();
+        const validData = this._getValidData();
+        if (!validData.length) {
+            return false;
+        }
+        return !this._$showAllStatistics(validData);
     }
 
     /**

--- a/src/jigsaw/pc-components/select/select.html
+++ b/src/jigsaw/pc-components/select/select.html
@@ -45,7 +45,7 @@
                         [enableIndeterminate]="true">
                         <span>{{'select.selectAll' | translate}}</span>
                     </jigsaw-checkbox>
-                    <div class="jigsaw-select-show-selected" *ngIf="!_$showSelected" (click)="_$showSelected = true">
+                    <div class="jigsaw-select-show-selected" *ngIf="!_$showSelected && _$showNumStatistics()" (click)="_$showSelected = true">
                         <span>{{'select.checkSelected' | translate}}</span>
                     </div>
                     <div class="jigsaw-select-show-all" *ngIf="_$showSelected" (click)="_$showSelected = false">

--- a/src/jigsaw/pc-components/upload/upload.scss
+++ b/src/jigsaw/pc-components/upload/upload.scss
@@ -27,7 +27,7 @@ $jigsaw-collapse: #{$jigsaw-prefix}-collapse;
             .#{$jigsaw-upload}-drop-icon {
                 height: 55%;
                 font-size: $icon-size-status-lg;
-                color: $icon-color-default;
+                color: $border-color-default;
             }
 
             .#{$jigsaw-upload}-drop-text {


### PR DESCRIPTION
- [x] input focus颜色
![image](https://user-images.githubusercontent.com/41236821/216246639-0bd02fa3-5997-4fa6-97ce-7afe6273bf83.png)
- [x] 图标颜色、图标禁用颜色
- [x] select优化显示已选的时机
![image](https://user-images.githubusercontent.com/41236821/216253312-fa43b848-8f2b-4cd1-8b85-8b5150a9a7f6.png)
- [x] time-picker弹出区域左对齐
![image](https://user-images.githubusercontent.com/41236821/216267472-2a475435-4343-4e56-b24d-da1051babd76.png)

