### PR TITLE
[破坏性修改] 去除组件库对echarts的依赖，关联@6186

### DIFF
--- a/angular.real.json
+++ b/angular.real.json
@@ -75,7 +75,8 @@
               "node_modules/moment/min/moment.min.js",
               "node_modules/ztree/js/jquery.ztree.all.js",
               "node_modules/ztree/js/jquery.ztree.exhide.js",
-              "node_modules/peity/jquery.peity.min.js"
+              "node_modules/peity/jquery.peity.min.js",
+              "node_modules/echarts/dist/echarts.js"
             ]
           },
           "configurations": {
@@ -249,7 +250,8 @@
               "node_modules/prismjs/prism.js",
               "node_modules/prismjs/components/prism-typescript.js",
               "node_modules/prismjs/plugins/normalize-whitespace/prism-normalize-whitespace.min.js",
-              "node_modules/prismjs/plugins/line-numbers/prism-line-numbers.min.js"
+              "node_modules/prismjs/plugins/line-numbers/prism-line-numbers.min.js",
+              "node_modules/echarts/dist/echarts.js"
             ]
           },
           "configurations": {

--- a/src/jigsaw/common/core/data/graph-data.ts
+++ b/src/jigsaw/common/core/data/graph-data.ts
@@ -3,7 +3,7 @@ import {TableDataBase} from "./table-data";
 import {CommonUtils} from "../utils/common-utils";
 import {Type} from "@angular/core";
 
-import echarts from "echarts";
+declare const echarts: any;
 import {JigsawTheme} from "../theming/theme";
 
 export type GraphMatrixRow = (string | number)[];

--- a/src/jigsaw/mobile-components/graph/graph.ts
+++ b/src/jigsaw/mobile-components/graph/graph.ts
@@ -7,10 +7,8 @@ import {AbstractGraphData} from "../../common/core/data/graph-data";
 import {CallbackRemoval, CommonUtils} from "../../common/core/utils/common-utils";
 import {AbstractJigsawComponent} from "../../common/common";
 import {EchartOptions} from "../../common/core/data/echart-types";
-import {JigsawTheme} from "../../common/core/theming/theme";
-import {darkGraphTheme, lightGraphTheme} from "../../common/core/theming/echarts-theme";
 
-import echarts from "echarts";
+declare const echarts: any;
 
 @Component({
     selector: 'jigsaw-mobile-graph, jm-graph',

--- a/src/jigsaw/pc-components/graph/graph-download.directive.ts
+++ b/src/jigsaw/pc-components/graph/graph-download.directive.ts
@@ -11,7 +11,7 @@ import {CommonUtils} from "../../common/core/utils/common-utils";
 import * as FileSaver from 'file-saver';
 import * as JSZip from 'jszip';
 
-import echarts from "echarts";
+declare const echarts: any;
 
 @Directive({
     selector: '[j-graph-download], [jigsaw-graph-download], [jigsawGraphDownload]'

--- a/src/jigsaw/pc-components/graph/graph.ts
+++ b/src/jigsaw/pc-components/graph/graph.ts
@@ -22,7 +22,7 @@ import {AbstractJigsawComponent, WingsTheme} from "../../common/common";
 import {EchartOptions} from "../../common/core/data/echart-types";
 import {JigsawTheme} from "../../common/core/theming/theme";
 
-import echarts from "echarts";
+declare const echarts: any;
 
 // 某些情况，需要把Jigsaw在服务端一起编译，直接使用window对象，会导致后端编译失败
 declare const window: any;
@@ -341,12 +341,15 @@ export class JigsawGraph extends AbstractJigsawComponent implements OnInit, OnDe
 
     /* *************** 事件声明 start ***************************** */
     // 1. 像饼图的事件等放到对应的组件中
-    private _eventArr = ['click', 'dblclick', 'mousedown', 'mouseup', 'mouseover', 'mouseout',
-        'globalout', 'contextmenu', 'legendselectchanged', 'legendselected', 'legendunselected',
-        'datazoom', 'datarangeselected', 'timelinechanged', 'timelineplaychanged', 'restore',
-        'dataviewchanged', 'magictypechanged', 'geoselectchanged', 'geoselected', 'geounselected',
-        'pieselectchanged', 'pieselected', 'pieunselected', 'mapselectchanged', 'mapselected',
-        'brush', 'brushselected'];
+    private _eventArr = [
+        'click', 'dblclick', 'mousedown', 'mouseup', 'mouseover', 'mouseout', 'globalout', 'contextmenu',
+        'legendselectchanged', 'legendselected', 'legendunselected', 'legendselectall', 'legendinverseselect', 'legendscroll',
+        'datazoom', 'datarangeselected', 'timelinechanged', 'timelineplaychanged', 'restore', 'dataviewchanged', 'magictypechanged',
+        'geoselectchanged', 'geoselected', 'geounselected', 'pieselectchanged', 'pieselected', 'pieunselected',
+        'mapselectchanged', 'mapselected', 'mapunselected', 'axisareaselected', 'focusnodeadjacency', 'unfocusnodeadjacency',
+        'highlight', 'downplay', 'selectchanged', 'graphroam', 'georoam', 'treeroam', 'brush', 'brushEnd', 'brushselected',
+        'globalcursortaken', 'rendered', 'finished'
+    ];
 
     // **************** 鼠标事件 start
     @Output()
@@ -376,12 +379,16 @@ export class JigsawGraph extends AbstractJigsawComponent implements OnInit, OnDe
 
     @Output()
     public legendselectchanged = new EventEmitter<any>();
-
     @Output()
     public legendselected = new EventEmitter<any>();
-
     @Output()
     public legendunselected = new EventEmitter<any>();
+    @Output()
+    public legendselectall = new EventEmitter<any>();
+    @Output()
+    public legendinverseselect = new EventEmitter<any>();
+    @Output()
+    public legendscroll = new EventEmitter<any>();
 
     @Output()
     public datazoom = new EventEmitter<any>();
@@ -424,15 +431,36 @@ export class JigsawGraph extends AbstractJigsawComponent implements OnInit, OnDe
     public axisareaselected = new EventEmitter<any>();
     // basic
     @Output()
-    public focusNodeAdjacency = new EventEmitter<any>();
+    public focusnodeadjacency = new EventEmitter<any>();
     @Output()
-    public unfocusNodeAdjacency = new EventEmitter<any>();
+    public unfocusnodeadjacency = new EventEmitter<any>();
 
     // 区域选择
     @Output()
     public brush = new EventEmitter<any>();
     @Output()
+    public brushEnd = new EventEmitter<any>();
+    @Output()
     public brushselected = new EventEmitter<any>();
+    @Output()
+    public globalcursortaken = new EventEmitter<any>();
+    @Output()
+    public rendered = new EventEmitter<any>();
+    @Output()
+    public finished = new EventEmitter<any>();
+
+    @Output()
+    public highlight = new EventEmitter<any>();
+    @Output()
+    public downplay = new EventEmitter<any>();
+    @Output()
+    public selectchanged = new EventEmitter<any>();
+    @Output()
+    public graphroam = new EventEmitter<any>();
+    @Output()
+    public georoam = new EventEmitter<any>();
+    @Output()
+    public treeroam = new EventEmitter<any>();
 
     // 将onInit 暴露给外面
     @Output()


### PR DESCRIPTION
应用在使用jigsaw组件时，如果使用了图形组件，需要做这样的调整：
1. 去除代码中，对echarts库的直接import，改为declare方式，如 `declare const echarts: any`。
2. 需要在angular.json或者index.html中，引入echarts。