### PR TITLE
[破坏性修改] 去除组件库对echarts的直接依赖，关联@6186

### DIFF
--- a/angular.real.json
+++ b/angular.real.json
@@ -75,7 +75,8 @@
               "node_modules/moment/min/moment.min.js",
               "node_modules/ztree/js/jquery.ztree.all.js",
               "node_modules/ztree/js/jquery.ztree.exhide.js",
-              "node_modules/peity/jquery.peity.min.js"
+              "node_modules/peity/jquery.peity.min.js",
+              "node_modules/echarts/dist/echarts.js"
             ]
           },
           "configurations": {
@@ -249,7 +250,8 @@
               "node_modules/prismjs/prism.js",
               "node_modules/prismjs/components/prism-typescript.js",
               "node_modules/prismjs/plugins/normalize-whitespace/prism-normalize-whitespace.min.js",
-              "node_modules/prismjs/plugins/line-numbers/prism-line-numbers.min.js"
+              "node_modules/prismjs/plugins/line-numbers/prism-line-numbers.min.js",
+              "node_modules/echarts/dist/echarts.js"
             ]
           },
           "configurations": {

--- a/src/jigsaw/common/core/data/graph-data.ts
+++ b/src/jigsaw/common/core/data/graph-data.ts
@@ -3,7 +3,7 @@ import {TableDataBase} from "./table-data";
 import {CommonUtils} from "../utils/common-utils";
 import {Type} from "@angular/core";
 
-import echarts from "echarts";
+declare const echarts: any;
 import {JigsawTheme} from "../theming/theme";
 
 export type GraphMatrixRow = (string | number)[];

--- a/src/jigsaw/mobile-components/graph/graph.ts
+++ b/src/jigsaw/mobile-components/graph/graph.ts
@@ -8,7 +8,7 @@ import {CallbackRemoval, CommonUtils} from "../../common/core/utils/common-utils
 import {AbstractJigsawComponent} from "../../common/common";
 import {EchartOptions} from "../../common/core/data/echart-types";
 
-import echarts from "echarts";
+declare const echarts: any;
 
 @Component({
     selector: 'jigsaw-mobile-graph, jm-graph',

--- a/src/jigsaw/pc-components/graph/graph-download.directive.ts
+++ b/src/jigsaw/pc-components/graph/graph-download.directive.ts
@@ -11,7 +11,7 @@ import {CommonUtils} from "../../common/core/utils/common-utils";
 import * as FileSaver from 'file-saver';
 import * as JSZip from 'jszip';
 
-import echarts from "echarts";
+declare const echarts: any;
 
 @Directive({
     selector: '[j-graph-download], [jigsaw-graph-download], [jigsawGraphDownload]'

--- a/src/jigsaw/pc-components/graph/graph.ts
+++ b/src/jigsaw/pc-components/graph/graph.ts
@@ -22,7 +22,7 @@ import {AbstractJigsawComponent, WingsTheme} from "../../common/common";
 import {EchartOptions} from "../../common/core/data/echart-types";
 import {JigsawTheme} from "../../common/core/theming/theme";
 
-import echarts from "echarts";
+declare const echarts: any;
 
 // 某些情况，需要把Jigsaw在服务端一起编译，直接使用window对象，会导致后端编译失败
 declare const window: any;


### PR DESCRIPTION
如果应用中未直接使用echarts，而是在使用jigsaw组件时使用了图形组件，则需要做这样的调整：
1. 去除代码中，对echarts库的直接import，改为declare方式，如 declare const echarts: any。
2. 需要在angular.json或者index.html中，引入echarts。