### PR TITLE
[故障] 解决了树穿梭框，树节点依旧可以编辑的问题，解决了@5161

### DIFF
--- a/src/app/for-internal/demo/pc/transfer/transfer-tree/demo.component.css
+++ b/src/app/for-internal/demo/pc/transfer/transfer-tree/demo.component.css
@@ -1,7 +1,10 @@
-.demo-item {
-    padding-top: 5px;
+.demo-options .demo-options-item {
+    display: flex;
+    align-items: center;
+    margin-bottom: 5px;
 }
 
-.demo-item .item-buttons {
-    padding: 2px 0;
+.demo-options .demo-options-item>span:not(:first-of-type),
+.demo-options .demo-options-item>jigsaw-button:not(:first-of-type) {
+    margin-left: 5px;
 }

--- a/src/app/for-internal/demo/pc/transfer/transfer-tree/demo.component.html
+++ b/src/app/for-internal/demo/pc/transfer/transfer-tree/demo.component.html
@@ -7,23 +7,24 @@
 
 <jigsaw-header [level]="1">Transfer(tree to list)</jigsaw-header>
 
-<jigsaw-header [level]="2">普通数据</jigsaw-header>
-<ul>
-    <li class="demo-item">
-        <div class="item-buttons">
-            <span>输入数据：</span>
-            <jigsaw-button (click)="changeDataFromObject()">通过fromObject()更新</jigsaw-button>
-        </div>
-
-        <div class="item-buttons">
-            <span>数据重置：</span>
-            <jigsaw-button (click)="resetInputData()">重置输入数据</jigsaw-button>
-            <jigsaw-button (click)="resetSelectedData()">重置已穿梭数据</jigsaw-button>
-        </div>
+<ul class="demo-options">
+    <li class="demo-options-item">
+        <span>输入数据类型：</span>
+        <jigsaw-button (click)="isAjax = !isAjax; resetData()" [disabled]="!isAjax">普通数据</jigsaw-button>
+        <jigsaw-button (click)="isAjax = !isAjax; resetData()" [disabled]="isAjax">服务器数据</jigsaw-button>
     </li>
-    <li class="demo-item">
-        <j-transfer width="100%" height="500" [data]="data" [selectedItems]="selectedData"
-                    [sourceRenderer]="sourceRenderer" [destRenderer]="targetRenderer"
-                    (selectedItemsChange)="selectedItemsChange($event)"></j-transfer>
+    <li class="demo-options-item">
+        <span>输入数据编辑：</span>
+        <jigsaw-button (click)="changeData()" [disabled]="isAjax">修改</jigsaw-button>
+        <jigsaw-button (click)="resetData()">重置</jigsaw-button>
+    </li>
+
+    <li class="demo-options-item">
+        <span>已穿梭数据：</span>
+        <jigsaw-button (click)="resetSelectedData()">重置</jigsaw-button>
     </li>
 </ul>
+
+<jigsaw-header>穿梭框</jigsaw-header>
+<j-transfer width="100%" height="500" [data]="data" [selectedItems]="selectedData" [sourceRenderer]="sourceRenderer"
+    [destRenderer]="targetRenderer" (selectedItemsChange)="selectedItemsChange($event)"></j-transfer>

--- a/src/app/for-internal/demo/pc/transfer/transfer-tree/demo.component.ts
+++ b/src/app/for-internal/demo/pc/transfer/transfer-tree/demo.component.ts
@@ -11,10 +11,10 @@ export class TransferTreeDemoComponent {
     public sourceRenderer = TransferTreeSourceRenderer;
     public targetRenderer = TransferListDestRenderer;
 
+    isAjax = false;
+
     constructor(public http: HttpClient) {
-        this.data = new SimpleTreeData();
-        this.data.http = http;
-        this.data.fromAjax("mock-data/tree-data");
+        this.resetData();
 
         this.selectedData = new ArrayCollection([
             { label: "叶子节点112", id: 2 },
@@ -28,7 +28,48 @@ export class TransferTreeDemoComponent {
     labelField = 'label';
     trackItemBy = 'label';
 
-    changeDataFromObject() {
+    changeData(){
+        this.data.fromObject(
+            [
+                {
+                    label: "父节点1",
+                    open: true,
+                    nodes: [
+                        {
+                            label: "父节点11",
+                            open: true,
+                            nodes: [
+                                { label: "修改节点111", id: 1 },
+                                { label: "修改节点112", id: 2 },
+                                { label: "修改节点113", id: 3 },
+                                { label: "修改节点114", id: 4 }
+                            ]
+                        },
+                        {
+                            label: "父节点12",
+                            nodes: [
+                                { label: "修改节点121", id: 5 },
+                                { label: "修改节点122", id: 6 },
+                                { label: "修改节点123", id: 7 },
+                                { label: "修改节点124", id: 8 }
+                            ]
+                        }
+                    ]
+                },
+            ]
+        );
+
+    }
+
+    resetData(){
+        if (this.isAjax){
+            this.data = new SimpleTreeData();
+            this.data.http = this.http;
+            this.data.fromAjax("mock-data/tree-data");
+            return;
+        }
+
+        this.data = new SimpleTreeData();
         this.data.fromObject(
             [
                 {
@@ -95,12 +136,6 @@ export class TransferTreeDemoComponent {
                 }
             ]
         );
-    }
-
-    resetInputData() {
-        this.data = new SimpleTreeData();
-        this.data.http = this.http;
-        this.data.fromAjax("mock-data/tree-data");
     }
 
     selectedItemsChange($event) {

--- a/src/jigsaw/pc-components/transfer/renderer/transfer-renderer.ts
+++ b/src/jigsaw/pc-components/transfer/renderer/transfer-renderer.ts
@@ -482,7 +482,22 @@ export abstract class TransferTreeRendererBase extends AbstractTransferRendererB
     }
 
     ngAfterViewInit() {
-        this.treeExt.setting.edit.enable = false;
+        this.treeExt.setting = {
+            data: {
+                key: {
+                    children: 'nodes',
+                    name: this.labelField
+                }
+            },
+            edit: {
+                enable: false
+            },
+            check: {
+                enable: true,
+                chkStyle: "checkbox",
+                chkboxType: { "Y": "ps", "N": "ps" }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41236821/229714508-6b5313ae-ae4e-47af-9d37-fbdd6952614c.png)

http://localhost:4200/#/pc/transfer/transfer-tree