### PR TITLE
[新增] 级联菜单组件在文本超出时显示tooltip，关联了@5181

### DIFF
--- a/src/jigsaw/pc-components/menu/menu.html
+++ b/src/jigsaw/pc-components/menu/menu.html
@@ -17,14 +17,12 @@
         (click)="!node.disabled && !!node.label && select.emit(node);
                  !node.disabled && !!node.label && initData?.select?.emit(node);"
         (mouseenter)="_$mouseenter(index, node)" (mouseleave)="_$mouseleave(index)">
-        <div class="jigsaw-menu-list-title" *ngIf="!!node.label && _$realTheme != 'navigation'"
-            [title]="_$getTitle(node.label,index,'jigsaw-menu-list-title')">
+        <div class="jigsaw-menu-list-title" *ngIf="!!node.label && _$realTheme != 'navigation'">
             <i class="{{node.icon}}"></i>
-            <span>{{node.label}}</span>
+            <span [jigsawTooltip]="node.label" jigsawTooltipOverflowOnly="true">{{node.label}}</span>
         </div>
-        <div class="jigsaw-menu-list-sub-title" *ngIf="_$realTheme != 'navigation'"
-            [title]="_$getTitle(node.subTitle,index,'jigsaw-menu-list-sub-title')">
-            <span *ngIf="!!node.subTitle">{{node.subTitle}}</span>
+        <div class="jigsaw-menu-list-sub-title" *ngIf="_$realTheme != 'navigation'">
+            <span *ngIf="!!node.subTitle" [jigsawTooltip]="node.subTitle" jigsawTooltipOverflowOnly="true">{{node.subTitle}}</span>
             <i *ngIf="!!node.subIcon" class="{{node.subIcon}} jigsaw-menu-subIcon"></i>
             <i *ngIf="node.nodes && node.nodes.length>0" class="iconfont iconfont-e144"></i>
         </div>

--- a/src/jigsaw/pc-components/menu/menu.html
+++ b/src/jigsaw/pc-components/menu/menu.html
@@ -19,7 +19,7 @@
         (mouseenter)="_$mouseenter(index, node)" (mouseleave)="_$mouseleave(index)">
         <div class="jigsaw-menu-list-title" *ngIf="!!node.label && _$realTheme != 'navigation'">
             <i class="{{node.icon}}"></i>
-            <span [jigsawTooltip]="node.label" jigsawTooltipOverflowOnly="true">{{node.label}}</span>
+            <span [jigsawTooltip]="node.label" jigsawTooltipOverflowOnly="true" jigsawTooltipPosition="topLeft">{{node.label}}</span>
         </div>
         <div class="jigsaw-menu-list-sub-title" *ngIf="_$realTheme != 'navigation'">
             <span *ngIf="!!node.subTitle" [jigsawTooltip]="node.subTitle" jigsawTooltipOverflowOnly="true">{{node.subTitle}}</span>

--- a/src/jigsaw/pc-components/menu/menu.ts
+++ b/src/jigsaw/pc-components/menu/menu.ts
@@ -258,18 +258,6 @@ export class JigsawMenu extends AbstractJigsawComponent implements IPopupable, A
         }
     }
 
-    /**
-     * @internal
-     */
-    public _$getTitle(label: string, index: number, titleClass: string): string {
-        if (!this._menuListElement || !label) {
-            return '';
-        }
-        const listOptionElements = this._menuListElement.nativeElement.children;
-        const titleElement = listOptionElements[index].getElementsByClassName(titleClass)[0];
-        return titleElement && titleElement.scrollWidth > titleElement.offsetWidth ? label : '';
-    }
-
     public static show(event: MouseEvent, options: MenuOptions | SimpleTreeData,
                        callback?: (node: SimpleNode) => void, context?: any): PopupInfo {
         if (!event) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41236821/230285367-00fb1ce4-0df0-469c-a49c-d32747d6035d.png)

