### PR TITLE
[优化] 解决直角系可视化组件配置公共系列不生效的问题，解决了@5183

### DIFF
--- a/src/jigsaw/common/core/data/modeled-graph-data.ts
+++ b/src/jigsaw/common/core/data/modeled-graph-data.ts
@@ -336,9 +336,9 @@ export class ModeledRectangularGraphData extends AbstractModeledGraphData {
                         seriesData['type'] = dim.shade;
                     }
                     seriesData['yAxisIndex'] = dim.yAxisIndex;
-                    seriesData['stack'] = dim.stack;
-                    seriesData['color'] = dim.color;
-                    seriesData['barWidth'] = dim.barWidth;
+                    seriesData['stack'] = dim.stack ? dim.stack : seriesData['stack'];
+                    seriesData['color'] = dim.color ? dim.color : seriesData['color'];
+                    seriesData['barWidth'] = dim.barWidth ? dim.barWidth : seriesData['barWidth'];
                     // 维度值里面设置了双坐标，而模板是单坐标的，需要转为双坐标，不然会报错
                     this._correctDoubleYAxis(dim, options);
                     this._autoRange(seriesData, options);


### PR DESCRIPTION
在awade中配置直角坐标系的公共系列的这三个参数，能够影响未设置参数的维度
