### PR TITLE
[故障] 解决tabs组件在页签较多出现下拉列表时，挡住最后一个页签标题的问题，关联@5035

### DIFF
--- a/src/jigsaw/mobile-components/tabs/tab.scss
+++ b/src/jigsaw/mobile-components/tabs/tab.scss
@@ -38,9 +38,9 @@ $tab-prefix: #{$jigsaw-prefix}-tabs;
     }
 
     &-overflow-button {
-        position: absolute;
-        top: 0;
-        right: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         cursor: pointer;
         font-size: 24px;
         color: $text-color-secondary;
@@ -79,6 +79,7 @@ $tab-prefix: #{$jigsaw-prefix}-tabs;
         box-sizing: border-box;
         position: relative;
         white-space: nowrap;
+        display: flex;
 
         .#{$tab-prefix}-ink-bar {
             position: absolute;

--- a/src/jigsaw/mobile-components/tabs/tab.scss
+++ b/src/jigsaw/mobile-components/tabs/tab.scss
@@ -38,9 +38,9 @@ $tab-prefix: #{$jigsaw-prefix}-tabs;
     }
 
     &-overflow-button {
-        display: flex;
-        align-items: center;
-        justify-content: center;
+        position: absolute;
+        top: 0;
+        right: 0;
         cursor: pointer;
         font-size: 24px;
         color: $text-color-secondary;
@@ -79,7 +79,6 @@ $tab-prefix: #{$jigsaw-prefix}-tabs;
         box-sizing: border-box;
         position: relative;
         white-space: nowrap;
-        display: flex;
 
         .#{$tab-prefix}-ink-bar {
             position: absolute;

--- a/src/jigsaw/pc-components/tabs/tab.scss
+++ b/src/jigsaw/pc-components/tabs/tab.scss
@@ -230,7 +230,6 @@ $jigsaw-list: #{$jigsaw-prefix}-list;
                 background-color: var(--jigsaw-nav-background, $bg-component);
                 font-size: 24px;
                 color: $icon-color-default;
-                text-align: center;
                 cursor: pointer;
 
                 &:hover {

--- a/src/jigsaw/pc-components/tabs/tab.scss
+++ b/src/jigsaw/pc-components/tabs/tab.scss
@@ -66,11 +66,11 @@ $jigsaw-list: #{$jigsaw-prefix}-list;
 
         .#{$jigsaw-tabs}-nav-container {
             position: relative;
+            display: flex;
             font-size: $font-size-lg;
             line-height: 1.5;
             white-space: nowrap;
             box-sizing: border-box;
-            display: flex;
 
             .#{$jigsaw-tabs}-ink-bar {
                 position: absolute;

--- a/src/jigsaw/pc-components/tabs/tab.scss
+++ b/src/jigsaw/pc-components/tabs/tab.scss
@@ -70,6 +70,7 @@ $jigsaw-list: #{$jigsaw-prefix}-list;
             line-height: 1.5;
             white-space: nowrap;
             box-sizing: border-box;
+            display: flex;
 
             .#{$jigsaw-tabs}-ink-bar {
                 position: absolute;
@@ -123,7 +124,7 @@ $jigsaw-list: #{$jigsaw-prefix}-list;
                         transition: color 0.3s $ease-in-out;
                         cursor: pointer;
                         text-decoration: none;
-                        
+
                         &:not(.#{$jigsaw-tabs}-tab-disabled):hover {
                             background: $brand-lighten;
                         }
@@ -221,9 +222,9 @@ $jigsaw-list: #{$jigsaw-prefix}-list;
             }
 
             .#{$jigsaw-tabs}-overflow-button {
-                position: absolute;
-                top: 0;
-                right: 0;
+                display: flex;
+                align-items: center;
+                justify-content: center;
                 width: 40px;
                 height: 100%;
                 background-color: var(--jigsaw-nav-background, $bg-component);
@@ -261,24 +262,6 @@ $jigsaw-list: #{$jigsaw-prefix}-list;
 
             &:hover {
                 color: $brand-default;
-            }
-        }
-
-        .#{$jigsaw-tabs}-overflow-button {
-            position: absolute;
-            top: 0;
-            right: 0;
-            width: 40px;
-            height: 100%;
-            background-color: var(--jigsaw-nav-background, $bg-component);
-            font-size: 24px;
-            color: $icon-color-default;
-            text-align: center;
-            cursor: pointer;
-
-            &:hover {
-                background-color: $brand-default;
-                color: $font-color-white;
             }
         }
     }


### PR DESCRIPTION
修改前：
![1](https://github.com/rdkmaster/jigsaw/assets/42016535/b62be65d-141f-4bb8-88b3-33cc4ca23838)

修改后：
![2](https://github.com/rdkmaster/jigsaw/assets/42016535/43f2a5bd-3aa8-4b87-9e1a-349575231e86)
