### PR TITLE
[故障] 解决数字输入框在表单中使用时，清空值不会触发表单校验的问题，关联了@4792

### DIFF
--- a/src/jigsaw/pc-components/input/numeric-input.ts
+++ b/src/jigsaw/pc-components/input/numeric-input.ts
@@ -210,6 +210,7 @@ export class JigsawNumericInput extends AbstractJigsawComponent implements Contr
             if (this.initialized) {
                 this.valueChange.emit(this._value);
             }
+            this._propagateChange(this._value);
             this._cdr.markForCheck();
             return;
         }


### PR DESCRIPTION
![demo](https://github.com/rdkmaster/jigsaw/assets/42016535/28dd614e-5293-450a-8dea-6949cfcbfcd2)
