### PR TITLE
[新增] 表单模块下select组件的增加manualSearch属性和searchKeywordChange事件，关联@4597

### DIFF
--- a/src/app/for-internal/demo/pc/form/template-driven/demo.component.html
+++ b/src/app/for-internal/demo/pc/form/template-driven/demo.component.html
@@ -48,7 +48,7 @@
     <div class="field">
         <label>Come From</label>
         <jigsaw-select [(ngModel)]="comeFrom" name="comeFrom" placeholder="Where are you come from"
-                       width="250px" [optionCount]="5"
+                       width="250px" [optionCount]="5" [searchable]="true" [manualSearch]="true" (searchKeywordChange)="searchKeywordChange()"
                        [data]="[
                             {label: 'Bei Jing'}, {label: 'Shang Hai'}, {label: 'Nan Jing'}, {label: 'Shen Zhen'},
                             {label: 'Chang Sha'}, {label: 'Cheng Du'}, {label: 'Chong Qing'}, {label: 'Hong Kong'},
@@ -108,5 +108,3 @@
     <p>Submit the form, and the form value should be shown here:</p>
     <p>{{formValue|json}}</p>
 </div>
-
-

--- a/src/app/for-internal/demo/pc/form/template-driven/demo.component.ts
+++ b/src/app/for-internal/demo/pc/form/template-driven/demo.component.ts
@@ -71,6 +71,10 @@ export class TemplateDrivenDemoComponent {
         }
     }
 
+    public searchKeywordChange() {
+        console.log("搜索框内容改变了")
+    }
+
     // ====================================================================
     // ignore the following lines, they are not important to this demo
     // ====================================================================

--- a/src/ngx-formly/jigsaw/select/src/select.type.ts
+++ b/src/ngx-formly/jigsaw/select/src/select.type.ts
@@ -29,12 +29,15 @@ import {ArrayCollection, JigsawSelect} from "@rdkmaster/jigsaw";
             [useStatistics]="to.useStatistics"
             [theme]="to.theme"
             [data]="to.data"
+            [manualSearch]="to.manualSearch"
+            [searchDebounce]="to.searchDebounce"
             [(value)]="to.value"
             (valueChange)="_$valueChange($event)"
             (remove)="to.remove && to.remove($event)"
+            (searchKeywordChange)="to.searchKeywordChange && to.searchKeywordChange($event)"
         ></jigsaw-select>
     `,
-    changeDetection: ChangeDetectionStrategy.OnPush,
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FormlyFieldSelect extends FormlyFieldType<JigsawSelect> {
     defaultOptions = {


### PR DESCRIPTION
由于在表单中select组件是充满的，所以size属性没有效果，其他的都同步了。
