### PR TITLE
[故障] 修复分组选择组件有初始选中项时点击查看已选按钮下拉框消失的问题，关联@4340

### DIFF
--- a/src/jigsaw/pc-components/select/select-base.ts
+++ b/src/jigsaw/pc-components/select/select-base.ts
@@ -220,7 +220,7 @@ export abstract class JigsawSelectBase extends AbstractJigsawComponent implement
 
     /**
      * @internal
-     */    
+     */
     public _$maxSelectionReachedChange($event: boolean) {
         this._$checkSelectAll();
         this.maxSelectionReachedChange.emit($event);
@@ -951,7 +951,7 @@ export abstract class JigsawSelectGroupBase extends JigsawSelectBase {
         if (!this.multipleSelect) {
             return;
         }
-        const data = (this._value as ArrayCollection<SelectOption>).toJSON();
+        const data = this._value instanceof ArrayCollection ? (this._value as ArrayCollection<SelectOption>).toJSON() : this._value;
         this._viewValue = this._getGroupedData(data);
     }
 
@@ -979,6 +979,7 @@ export abstract class JigsawSelectGroupBase extends JigsawSelectBase {
                 this._$selectedItems = new ArrayCollection([]);
             }
             this._$checkSelectAll();
+            this._updateViewValue();
             this._changeDetector.detectChanges();
         })
     }


### PR DESCRIPTION
Change-Id: I8b70e0c07431251d2acf5e121e1086074a515b01